### PR TITLE
Simplify the glob-to-regex issue

### DIFF
--- a/Common/src/main/java/net/createmod/catnip/data/Glob.java
+++ b/Common/src/main/java/net/createmod/catnip/data/Glob.java
@@ -32,7 +32,7 @@ public class Glob {
 				case '?' -> regex.append(".");
 				case ',' -> {
 					if (inGroup) {
-						regex.append(")|(?:");
+						regex.append("|");
 					} else {
 						regex.append(',');
 					}
@@ -117,12 +117,12 @@ public class Glob {
 						throw new PatternSyntaxException("Cannot nest groups", globPattern, i - 1);
 					}
 
-					regex.append("(?:(?:");
+					regex.append("(?:");
 					inGroup = true;
 				}
 				case '}' -> {
 					if (inGroup) {
-						regex.append("))");
+						regex.append(")");
 						inGroup = false;
 					} else {
 						regex.append('}');


### PR DESCRIPTION
I came across issue #2 on my own and tried fixing it myself, until I saw that it had already been fixed in [059de7f](https://github.com/Creators-of-Create/Ponder/commit/059de7feff0a6e3f74b89e3ee42c0f9641430028).

Although that fix does work, this is an easier way to fix the issue while also reducing regex complexity.

**Science behind it:**
When ignoring the difference between capturing and non-capturing groups
`((textOne)|(textTwo))` captures always identically to `(textOne|textTwo)`. That means that the extra braces aren't needed.
This also works when textOne or textTwo is a capture group itself and _makes nesting groups possible_ (e.g. `Text{{Simple,Extended}One,Two}` should match `TextSimpleOne`, `TextExtendedOne` and `TextTwo`), although that would need a new way to check for a nested `inGroup`.