### PR TITLE
Make PonderPlugin ordered

### DIFF
--- a/Common/src/main/java/net/createmod/ponder/api/registration/PonderPlugin.java
+++ b/Common/src/main/java/net/createmod/ponder/api/registration/PonderPlugin.java
@@ -1,9 +1,14 @@
 package net.createmod.ponder.api.registration;
 
+import java.util.Comparator;
+
+import net.createmod.catnip.platform.CatnipServices;
 import net.createmod.ponder.api.level.PonderLevel;
 import net.minecraft.resources.ResourceLocation;
 
 public interface PonderPlugin {
+	Comparator<PonderPlugin> ORDERING = Comparator.comparing(PonderPlugin::getModId,
+		Comparator.comparingInt(CatnipServices.PLATFORM.getLoadedMods()::indexOf));
 
 	/**
 	 * @return the modID of the mod that added this plugin

--- a/Common/src/main/java/net/createmod/ponder/foundation/PonderIndex.java
+++ b/Common/src/main/java/net/createmod/ponder/foundation/PonderIndex.java
@@ -1,7 +1,7 @@
 package net.createmod.ponder.foundation;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -28,7 +28,7 @@ public class PonderIndex {
 	private static final PonderSceneRegistry SCENES = new PonderSceneRegistry(LOCALIZATION);
 	private static final PonderTagRegistry TAGS = new PonderTagRegistry(LOCALIZATION);
 
-	private static final Set<PonderPlugin> plugins = new HashSet<>();
+	private static final Set<PonderPlugin> plugins = new TreeSet<>(PonderPlugin.ORDERING);
 
 	private static final Logger LOGGER = LogManager.getLogger("PonderIndex");
 


### PR DESCRIPTION
Currently, the `PonderIndex#plugins` is backed by a `HashSet` which is unordered, and therefore scenes added to the same component by different plugins is also unordered and even random (as `PonderPlugin` does not implement `hashCode`). 

This PR changed the `PonderIndex#plugins` to a `TreeSet` backed by a custom `Comparator`, which compares the plugins by their owning mods, where mod order is backed by the mod loader (Note: Only NeoForge/Forge has configurable mod sorting).