### PR TITLE
Glob modification

### DIFF
--- a/Common/src/main/java/net/createmod/catnip/data/Glob.java
+++ b/Common/src/main/java/net/createmod/catnip/data/Glob.java
@@ -117,7 +117,14 @@ public class Glob {
 						throw new PatternSyntaxException("Cannot nest groups", globPattern, i - 1);
 					}
 
-					regex.append("(?:");
+					regex.append("(?");
+					if (next(globPattern, i) == '!') {
+						regex.append('!');
+					} else {
+						regex.append(":");
+					}
+					++i;
+
 					inGroup = true;
 				}
 				case '}' -> {

--- a/Common/src/main/java/net/createmod/catnip/data/Glob.java
+++ b/Common/src/main/java/net/createmod/catnip/data/Glob.java
@@ -120,10 +120,10 @@ public class Glob {
 					regex.append("(?");
 					if (next(globPattern, i) == '!') {
 						regex.append('!');
+						++i;
 					} else {
 						regex.append(":");
 					}
-					++i;
 
 					inGroup = true;
 				}


### PR DESCRIPTION
I have noticed that the Glob.toRegexPattern function doesn't support negative lookahead word groups, so i've decided to change that. 
That's all i did. 5 lines of code so that i can do "{!bannedWord,BannedWord}-hello"... ur welcome :)
And yeah that's the syntax, it's the same as sets: "[!abc]"