### PR TITLE
Retains the style of rich text on the sign when removing the command

### DIFF
--- a/Common/src/main/java/net/createmod/catnip/nbt/NBTProcessors.java
+++ b/Common/src/main/java/net/createmod/catnip/nbt/NBTProcessors.java
@@ -2,7 +2,6 @@ package net.createmod.catnip.nbt;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
@@ -13,6 +12,7 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.item.EnchantedBookItem;
 import net.minecraft.world.item.ItemStack;
@@ -42,24 +42,39 @@ public final class NBTProcessors {
 	private static final UnaryOperator<CompoundTag> signProcessor = data -> {
 		var front_text = data.getCompound("front_text").getList("messages", Tag.TAG_STRING);
 		var back_text = data.getCompound("back_text").getList("messages", Tag.TAG_STRING);
-		for (int i = 0; i < 4; ++i) {
-			tryRemovingCommand(front_text, i);
-			tryRemovingCommand(back_text, i);
-		}
+		ListTag front_text2 = removeCommands(front_text);
+		ListTag back_text2 = removeCommands(back_text);
+		data.getCompound("front_text").put("messages",front_text2);
+		data.getCompound("back_text").put("messages",back_text2);
 		return data;
 	};
 
-	private static void tryRemovingCommand(ListTag front_text, int i) {
-		if(NBTProcessors.textComponentHasClickEvent(front_text.get(i).getAsString()))
+	private static ListTag removeCommands(ListTag inList) {
+		ListTag result = new ListTag();
+		inList.stream()
+			.map(t->
+				{
+					var component = Component.Serializer.fromJson(t.getAsString());
+					if(component != null) {
+						return StringTag.valueOf(Component.Serializer.toJson(
+							removeCommand(component)
+						));
+					}
+					return StringTag.valueOf("");
+				}
+			)
+			.forEach(result::add);
+		return result;
+	}
+
+	private static MutableComponent removeCommand(MutableComponent textComponent){
+		textComponent.setStyle(textComponent.getStyle().withClickEvent(null));
+		for(Component component : textComponent.getSiblings())
 		{
-			var text =
-				Component.Serializer.fromJson(front_text.get(i).getAsString());
-			if (text != null) {
-				text.setStyle(text.getStyle().withClickEvent(null));
-				front_text.remove(i);
-				front_text.add(i,net.minecraft.nbt.StringTag.valueOf(Component.Serializer.toJson(text)));
-			}
+			if(component instanceof MutableComponent textComponent2)
+				removeCommand(textComponent2);
 		}
+		return textComponent;
 	}
 	public static UnaryOperator<CompoundTag> itemProcessor(String tagKey) {
 		return data -> {

--- a/Common/src/main/java/net/createmod/catnip/nbt/NBTProcessors.java
+++ b/Common/src/main/java/net/createmod/catnip/nbt/NBTProcessors.java
@@ -9,6 +9,7 @@ import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
@@ -35,21 +36,31 @@ public final class NBTProcessors {
 	}
 
 	// Triggered by block tag, not BE type
+
+	// Remove the first layer of commands while preserving the styles.
+	// Since recursive commands won't be executed, there's no need to handle them.
 	private static final UnaryOperator<CompoundTag> signProcessor = data -> {
-		for (String key : List.of("front_text", "back_text")) {
-			CompoundTag textTag = data.getCompound(key);
-			if (!textTag.contains("messages", Tag.TAG_LIST))
-				continue;
-			for (Tag tag : textTag.getList("messages", Tag.TAG_STRING))
-				if (tag instanceof StringTag stringTag)
-					if (textComponentHasClickEvent(stringTag.getAsString()))
-						return null;
+		var front_text = data.getCompound("front_text").getList("messages", Tag.TAG_STRING);
+		var back_text = data.getCompound("back_text").getList("messages", Tag.TAG_STRING);
+		for (int i = 0; i < 4; ++i) {
+			tryRemovingCommand(front_text, i);
+			tryRemovingCommand(back_text, i);
 		}
-		if (data.contains("front_item") || data.contains("back_item"))
-			return null; // "Amendments" compat: sign data contains itemstacks
 		return data;
 	};
 
+	private static void tryRemovingCommand(ListTag front_text, int i) {
+		if(NBTProcessors.textComponentHasClickEvent(front_text.get(i).getAsString()))
+		{
+			var text =
+				Component.Serializer.fromJson(front_text.get(i).getAsString());
+			if (text != null) {
+				text.setStyle(text.getStyle().withClickEvent(null));
+				front_text.remove(i);
+				front_text.add(i,net.minecraft.nbt.StringTag.valueOf(Component.Serializer.toJson(text)));
+			}
+		}
+	}
 	public static UnaryOperator<CompoundTag> itemProcessor(String tagKey) {
 		return data -> {
 			CompoundTag compound = data.getCompound(tagKey);

--- a/Common/src/main/java/net/createmod/catnip/nbt/NBTProcessors.java
+++ b/Common/src/main/java/net/createmod/catnip/nbt/NBTProcessors.java
@@ -37,8 +37,7 @@ public final class NBTProcessors {
 
 	// Triggered by block tag, not BE type
 
-	// Remove the first layer of commands while preserving the styles.
-	// Since recursive commands won't be executed, there's no need to handle them.
+	// Remove commands while preserving the styles.
 	private static final UnaryOperator<CompoundTag> signProcessor = data -> {
 		var front_text = data.getCompound("front_text").getList("messages", Tag.TAG_STRING);
 		var back_text = data.getCompound("back_text").getList("messages", Tag.TAG_STRING);


### PR DESCRIPTION
Discovered an existing method for removing commands on the sign, but it simply and bluntly removed all text, so modifications were made
If agree to merge, please check whether [this issue](https://github.com/Creators-of-Create/Create/pull/8108) needs to be revisited