### PR TITLE
Glob: Negative Group changes

### DIFF
--- a/Common/src/main/java/net/createmod/catnip/data/Glob.java
+++ b/Common/src/main/java/net/createmod/catnip/data/Glob.java
@@ -23,18 +23,33 @@ public class Glob {
 		boolean inGroup = false;
 		StringBuilder regex = new StringBuilder("^");
 		int i = 0;
+		boolean isNegativeLookaround = false;
+		boolean isAnchored = true;
 
 		while(i < globPattern.length()) {
 			char c = globPattern.charAt(i++);
 
 			switch(c) {
-				case '*' -> regex.append(".*");
-				case '?' -> regex.append(".");
+				case '*' -> {
+					regex.append(".*");
+					if(!inGroup)
+					{
+						isAnchored = false;
+					}
+				}
+				case '?' -> {
+					regex.append(".");
+					if(!inGroup)
+					{
+						isAnchored = true;
+					}
+				}
 				case ',' -> {
 					if (inGroup) {
 						regex.append("|");
 					} else {
 						regex.append(',');
+						isAnchored = true;
 					}
 				}
 				case '[' -> {
@@ -99,6 +114,10 @@ public class Glob {
 					}
 
 					regex.append("]");
+					if(!inGroup)
+					{
+						isAnchored = true;
+					}
 				}
 				case '\\' -> {
 					if (i == globPattern.length()) {
@@ -111,6 +130,10 @@ public class Glob {
 					}
 
 					regex.append(next);
+					if(!inGroup)
+					{
+						isAnchored = true;
+					}
 				}
 				case '{' -> {
 					if (inGroup) {
@@ -119,9 +142,14 @@ public class Glob {
 
 					regex.append("(?");
 					if (next(globPattern, i) == '!') {
+						isNegativeLookaround = true;
+						if(!isAnchored) {
+							regex.append('<');
+						}
 						regex.append('!');
 						++i;
 					} else {
+						isNegativeLookaround = false;
 						regex.append(":");
 					}
 
@@ -130,9 +158,14 @@ public class Glob {
 				case '}' -> {
 					if (inGroup) {
 						regex.append(")");
+						if(isAnchored && isNegativeLookaround) {
+							regex.append('.*');
+							isAnchored = false
+						}
 						inGroup = false;
 					} else {
 						regex.append('}');
+						isAnchored = true;
 					}
 				}
 				default -> {
@@ -141,6 +174,10 @@ public class Glob {
 					}
 
 					regex.append(c);
+					if(!inGroup)
+					{
+						isAnchored = true;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Automatic choice of Look-ahead and Look-behind for negative groups. Automatic addition of .* so negative groups work more intuitively.

Look-arounds do not "consume" characters so `{!West}` does not work without a `*`, automatically adding that will make it easier to use.
If there is already a `*` before the negative group, the group is changed to a look behind group, and the `*` at the end is omitted.

behaviour can be tested here:
https://tobi-blackscale.github.io/Create-Glob-Tester/GlobRegExTest_new.html