### PR TITLE
get display names of mods from platform metadata

### DIFF
--- a/Common/src/main/java/net/createmod/catnip/config/ui/BaseConfigScreen.java
+++ b/Common/src/main/java/net/createmod/catnip/config/ui/BaseConfigScreen.java
@@ -1,7 +1,6 @@
 package net.createmod.catnip.config.ui;
 
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
@@ -17,6 +16,7 @@ import net.createmod.catnip.gui.widget.AbstractSimiWidget;
 import net.createmod.catnip.gui.widget.BoxWidget;
 import net.createmod.catnip.lang.FontHelper;
 import net.createmod.catnip.lang.FontHelper.Palette;
+import net.createmod.catnip.platform.CatnipServices;
 import net.createmod.catnip.theme.Color;
 import net.createmod.ponder.Ponder;
 import net.createmod.ponder.enums.PonderGuiTextures;
@@ -172,8 +172,7 @@ public class BaseConfigScreen extends ConfigScreen {
 			serverText.withElementRenderer(BoxWidget.gradientFactory.apply(serverConfigWidget));
 		}
 
-		TextStencilElement titleText = new TextStencilElement(font, getModDisplayName(modID).orElse(modID.toLowerCase(
-				Locale.ROOT)))
+		TextStencilElement titleText = new TextStencilElement(font, CatnipServices.PLATFORM.getModDisplayName(modID))
 				.centered(true, true)
 				.withElementRenderer((ms, w, h, alpha) -> {
 					UIRenderHelper.angledGradient(ms, 0, 0, h / 2, h, w / 2, COLOR_TITLE_A, COLOR_TITLE_B);

--- a/Common/src/main/java/net/createmod/catnip/config/ui/ConfigModListScreen.java
+++ b/Common/src/main/java/net/createmod/catnip/config/ui/ConfigModListScreen.java
@@ -120,7 +120,7 @@ public class ConfigModListScreen extends ConfigScreen {
 		protected String id;
 
 		public ModEntry(String id, Screen parent) {
-			super(modName(id));
+			super(CatnipServices.PLATFORM.getModDisplayName(id));
 			this.id = id;
 
 			button = new BoxWidget(0, 0, 35, 16)
@@ -133,15 +133,11 @@ public class ConfigModListScreen extends ConfigScreen {
 				button.active = false;
 				button.updateGradientFromState();
 				button.modifyElement(e -> ((DelegatedStencilElement) e).withElementRenderer(BaseConfigScreen.DISABLED_RENDERER));
-				labelTooltip.add(Component.literal(modName(id)));
+				labelTooltip.add(Component.literal(CatnipServices.PLATFORM.getModDisplayName(id)));
 				labelTooltip.addAll(FontHelper.cutTextComponent(Component.literal("This Mod does not have any configs registered or is not using Forge's config system"), Palette.ALL_GRAY));
 			}
 
 			listeners.add(button);
-		}
-
-		private static String modName(String modID) {
-			return getModDisplayName(modID).orElse(toHumanReadable(modID));
 		}
 
 		public String getId() {

--- a/Common/src/main/java/net/createmod/catnip/config/ui/ConfigScreen.java
+++ b/Common/src/main/java/net/createmod/catnip/config/ui/ConfigScreen.java
@@ -2,10 +2,7 @@ package net.createmod.catnip.config.ui;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -28,29 +25,10 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.client.renderer.PanoramaRenderer;
-import net.minecraft.client.resources.language.I18n;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 
 public abstract class ConfigScreen extends AbstractSimiScreen {
-
-	public static final List<UnaryOperator<String>> displayNameKeys = List.of(
-			modID -> "catnip." + modID + ".display_name",
-			modID -> "constants." + modID + ".mod_name",
-			modID -> "itemGroup." + modID + ".base",
-			modID -> "itemGroup." + modID + "." + modID
-	);
-
-	public static final Map<String, String> knownModDisplayNames = Map.ofEntries(
-			Map.entry("forge", "Forge"),
-			Map.entry("jei", "Just Enough Items"),
-			Map.entry("computercraft", "ComputerCraft"),
-			Map.entry("catnip", "Catnip"),
-			Map.entry("ponder", "Ponder"),
-			Map.entry("create", "Create"),
-			Map.entry("flywheel", "Flywheel"),
-			Map.entry("ae2", "Applied Energistics 2")
-	);
 
 	public static final Map<String, TriConsumer<Screen, GuiGraphics, Float>> backgrounds = new HashMap<>();
 	public static final PhysicalFloat cogSpin = PhysicalFloat.create().withLimit(10f).withDrag(0.3).addForce(new Force.Static(.2f));
@@ -120,24 +98,6 @@ public abstract class ConfigScreen extends AbstractSimiScreen {
 	@Override
 	public boolean isPauseScreen() {
 		return true;
-	}
-
-	/**
-	 * This method checks some language keys to see if the mod has declared a display name via lang.
-	 * If none of those succeed, it checks a list of manually declared ones for compatibility.
-	 */
-	public static Optional<String> getModDisplayName(String modID) {
-		Optional<String> displayNameFromLang = displayNameKeys
-				.stream()
-				.map(op -> op.apply(modID))
-				.filter(I18n::exists)
-				.findFirst()
-				.map(I18n::get);
-
-		if (displayNameFromLang.isPresent())
-			return displayNameFromLang;
-
-		return Optional.ofNullable(knownModDisplayNames.get(modID));
 	}
 
 	public static String toHumanReadable(String key) {

--- a/Common/src/main/java/net/createmod/catnip/platform/services/PlatformHelper.java
+++ b/Common/src/main/java/net/createmod/catnip/platform/services/PlatformHelper.java
@@ -39,6 +39,8 @@ public interface PlatformHelper {
 
 	List<String> getLoadedMods();
 
+	String getModDisplayName(String modId);
+
 	void executeOnClientOnly(Supplier<Runnable> toRun);
 
 	void executeOnServerOnly(Supplier<Runnable> toRun);

--- a/Common/src/main/java/net/createmod/ponder/foundation/ui/PonderTagIndexScreen.java
+++ b/Common/src/main/java/net/createmod/ponder/foundation/ui/PonderTagIndexScreen.java
@@ -13,7 +13,6 @@ import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 
-import net.createmod.catnip.config.ui.ConfigScreen;
 import net.createmod.catnip.gui.ScreenOpener;
 import net.createmod.catnip.gui.UIRenderHelper;
 import net.createmod.catnip.gui.element.BoxElement;
@@ -23,6 +22,7 @@ import net.createmod.catnip.lang.FontHelper;
 import net.createmod.catnip.lang.FontHelper.Palette;
 import net.createmod.catnip.layout.LayoutHelper;
 import net.createmod.catnip.layout.PaginationState;
+import net.createmod.catnip.platform.CatnipServices;
 import net.createmod.ponder.Ponder;
 import net.createmod.ponder.enums.PonderGuiTextures;
 import net.createmod.ponder.foundation.PonderIndex;
@@ -103,7 +103,7 @@ public class PonderTagIndexScreen extends AbstractPonderScreen {
 
 		paginationState.iterateForCurrentPage((iPage, iOverall) -> {
 			Map.Entry<String, List<PonderTag>> entry = sortedModTags.get(iOverall);
-			String modName = ConfigScreen.getModDisplayName(entry.getKey()).orElse(entry.getKey());
+			String modName = CatnipServices.PLATFORM.getModDisplayName(entry.getKey());
 			List<PonderTag> tags = entry.getValue();
 
 			LayoutHelper layout = LayoutHelper.centeredHorizontal(tags.size(), 1, 28, 28, 8);

--- a/Fabric/src/main/java/net/createmod/catnip/platform/FabricPlatformHelper.java
+++ b/Fabric/src/main/java/net/createmod/catnip/platform/FabricPlatformHelper.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import io.github.fabricators_of_create.porting_lib.util.EnvExecutor;
+import net.createmod.catnip.config.ui.ConfigScreen;
 import net.createmod.catnip.platform.services.PlatformHelper;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.FabricLoader;
@@ -37,6 +38,13 @@ public class FabricPlatformHelper implements PlatformHelper {
 		for (ModContainer mod : FabricLoader.getInstance().getAllMods())
 			modIds.add(mod.getMetadata().getId());
 		return modIds;
+	}
+
+	@Override
+	public String getModDisplayName(String modId) {
+		return FabricLoader.getInstance().getModContainer(modId)
+				.map(mod -> mod.getMetadata().getName())
+				.orElse(ConfigScreen.toHumanReadable(modId));
 	}
 
 	@Override

--- a/Forge/src/main/java/net/createmod/catnip/platform/ForgePlatformHelper.java
+++ b/Forge/src/main/java/net/createmod/catnip/platform/ForgePlatformHelper.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
+import net.createmod.catnip.config.ui.ConfigScreen;
 import net.createmod.catnip.platform.services.PlatformHelper;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.DistExecutor;
@@ -39,6 +40,13 @@ public class ForgePlatformHelper implements PlatformHelper {
 		for (IModInfo mod : ModList.get().getMods())
 			modIds.add(mod.getModId());
 		return modIds;
+	}
+
+	@Override
+	public String getModDisplayName(String modId) {
+		return ModList.get().getModContainerById(modId)
+				.map(mod -> mod.getModInfo().getDisplayName())
+				.orElse(ConfigScreen.toHumanReadable(modId));
 	}
 
 	@Override


### PR DESCRIPTION
rather than hardcoding a few names and relying on lang files, it's likely more compatible to use the loader's mod metadata apis to get the mod's display name from its `fabric.mod.json` or `mods.toml`.

Before:
<img width="856" alt="Before" src="https://github.com/user-attachments/assets/e9560922-d003-4c2c-908d-9380421c763e" />

After:
<img width="856" alt="After" src="https://github.com/user-attachments/assets/e7cfe899-93b8-449e-934e-5cc03def5653" />

mods that were previously hardcoded (such as AE2) stay the same, and others (guideme and ferritecore) now have fancy names!