### PR TITLE
Fix "Pondering about..." in Ponder Tag Screen being incompatible with Ponder Tags' translations

### DIFF
--- a/Common/src/main/java/net/createmod/ponder/foundation/registration/PonderLocalization.java
+++ b/Common/src/main/java/net/createmod/ponder/foundation/registration/PonderLocalization.java
@@ -125,6 +125,7 @@ public class PonderLocalization implements LangRegistryAccess {
 		addGeneral(consumer, PonderTooltipHandler.HOLD_TO_PONDER, "Hold [%1$s] to Ponder");
 		addGeneral(consumer, PonderTooltipHandler.SUBJECT, "Subject of this scene");
 		addGeneral(consumer, AbstractPonderScreen.PONDERING, "Pondering about...");
+		addGeneral(consumer, AbstractPonderScreen.PONDERING_TAG, "Pondering about...");
 		addGeneral(consumer, AbstractPonderScreen.IDENTIFY_MODE, "Identify mode active.\nUnpause with [%1$s]");
 		addGeneral(consumer, AbstractPonderScreen.ASSOCIATED, "Associated Entries");
 

--- a/Common/src/main/java/net/createmod/ponder/foundation/ui/AbstractPonderScreen.java
+++ b/Common/src/main/java/net/createmod/ponder/foundation/ui/AbstractPonderScreen.java
@@ -15,6 +15,7 @@ public abstract class AbstractPonderScreen extends NavigatableSimiScreen {
 	public static final String DESCRIPTION = UI_PREFIX + "index_description";
 
 	public static final String PONDERING = UI_PREFIX + "pondering";
+	public static final String PONDERING_TAG = UI_PREFIX + "pondering_tag";
 	public static final String IDENTIFY_MODE = UI_PREFIX + "identify_mode";
 	public static final String IN_CHAPTER = UI_PREFIX + "in_chapter";
 	public static final String IDENTIFY = UI_PREFIX + "identify";

--- a/Common/src/main/java/net/createmod/ponder/foundation/ui/PonderTagScreen.java
+++ b/Common/src/main/java/net/createmod/ponder/foundation/ui/PonderTagScreen.java
@@ -171,7 +171,7 @@ public class PonderTagScreen extends AbstractPonderScreen {
 				.withBounds(30, 30)
 				.render(graphics);
 
-		graphics.drawString(font, Ponder.lang().translate(AbstractPonderScreen.PONDERING).component(), x, y - 6, UIRenderHelper.COLOR_TEXT_DARKER.getFirst().getRGB(), false);
+		graphics.drawString(font, Ponder.lang().translate(AbstractPonderScreen.PONDERING_TAG).component(), x, y - 6, UIRenderHelper.COLOR_TEXT_DARKER.getFirst().getRGB(), false);
 		y += 8;
 		x += 0;
 		poseStack.translate(x, y, 0);

--- a/Common/src/main/resources/assets/ponder/lang/be_by.json
+++ b/Common/src/main/resources/assets/ponder/lang/be_by.json
@@ -1,5 +1,6 @@
 {
   "ponder.ui.pondering": "Разважаем над...",
+  "ponder.ui.pondering_tag": "Разважаем над...",
   "ponder.ui.next": "Наступная сцэна",
   "ponder.ui.next_up": "Далей: разважаць над",
   "ponder.ui.index_title": "Каталог разважанняў",

--- a/Common/src/main/resources/assets/ponder/lang/cs_cz.json
+++ b/Common/src/main/resources/assets/ponder/lang/cs_cz.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Podržte [%1$s] pro dumání",
   "ponder.ui.subject": "Předmět této scény",
   "ponder.ui.pondering": "Dumání o...",
+  "ponder.ui.pondering_tag": "Dumání o...",
   "ponder.ui.identify_mode": "Režim identifikace je aktivní.\nSpusťte pomocí [%1$s]",
   "ponder.ui.associated": "Přidružené položky",
   "ponder.ui.close": "Zavřít",

--- a/Common/src/main/resources/assets/ponder/lang/de_de.json
+++ b/Common/src/main/resources/assets/ponder/lang/de_de.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Halte [%1$s] für die Vorschau",
   "ponder.ui.subject": "Zielgegenstand",
   "ponder.ui.pondering": "Vorschau für...",
+  "ponder.ui.pondering_tag": "Vorschau für...",
   "ponder.ui.identify_mode": "Identifiziere den aktiven Modus.\nStarten mit [%1$s]",
   "ponder.ui.associated": "Verknüpfte Vorschau",
   "ponder.ui.close": "Schließen",

--- a/Common/src/main/resources/assets/ponder/lang/en_us.json
+++ b/Common/src/main/resources/assets/ponder/lang/en_us.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Hold [%1$s] to Ponder",
   "ponder.ui.subject": "Subject of this scene",
   "ponder.ui.pondering": "Pondering about...",
+  "ponder.ui.pondering_tag": "Pondering about...",
   "ponder.ui.identify_mode": "Identify mode active.\nUnpause with [%1$s]",
   "ponder.ui.associated": "Associated Entries",
   "ponder.ui.close": "Close",

--- a/Common/src/main/resources/assets/ponder/lang/eo_uy.json
+++ b/Common/src/main/resources/assets/ponder/lang/eo_uy.json
@@ -1,6 +1,7 @@
 {
   "ponder.ui.hold_to_ponder": "Detenu [%1$s] por pripensi",
   "ponder.ui.pondering": "Pensas pri...",
+  "ponder.ui.pondering_tag": "Pensas pri...",
   "ponder.ui.close": "Fermu",
   "ponder.ui.identify": "Identigu",
   "ponder.ponder.shared.sneak_and": "Kaŝi +",

--- a/Common/src/main/resources/assets/ponder/lang/es_cl.json
+++ b/Common/src/main/resources/assets/ponder/lang/es_cl.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": ">Mantén [%1$s] para reflexionar",
   "ponder.ui.subject": "Sujeto de esta escena",
   "ponder.ui.pondering": "Reflexionando sobre...",
+  "ponder.ui.pondering_tag": "Reflexionando sobre...",
   "ponder.ui.identify_mode": "Modo de identificación activado.\nDespausa con [%1$s]",
   "ponder.ui.associated": "Entradas asociadas",
   "ponder.ui.close": "Cerrar",

--- a/Common/src/main/resources/assets/ponder/lang/es_es.json
+++ b/Common/src/main/resources/assets/ponder/lang/es_es.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Mantén [%1$s] para considerar",
   "ponder.ui.subject": "Tema de esta escena",
   "ponder.ui.pondering": "Considerando sobre...",
+  "ponder.ui.pondering_tag": "Considerando sobre...",
   "ponder.ui.identify_mode": "Identificando modo activo.\nReanuda con [%1$s]",
   "ponder.ui.associated": "Entradas asociadas",
   "ponder.ui.close": "Cerrar",

--- a/Common/src/main/resources/assets/ponder/lang/es_mx.json
+++ b/Common/src/main/resources/assets/ponder/lang/es_mx.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Mantén [%1$s] para considerar",
   "ponder.ui.subject": "Tema de esta escena",
   "ponder.ui.pondering": "Considerando sobre...",
+  "ponder.ui.pondering_tag": "Considerando sobre...",
   "ponder.ui.identify_mode": "Identificando modo activo.\nReanuda con [%1$s]",
   "ponder.ui.associated": "Entradas asociadas",
   "ponder.ui.close": "Cerrar",

--- a/Common/src/main/resources/assets/ponder/lang/fi_fi.json
+++ b/Common/src/main/resources/assets/ponder/lang/fi_fi.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Pidä [%1$s] pohjassa pohtiaksesi",
   "ponder.ui.subject": "Tämän kohtauksen aihe",
   "ponder.ui.pondering": "Pohditaan...",
+  "ponder.ui.pondering_tag": "Pohditaan...",
   "ponder.ui.identify_mode": "Tunnistustila aktiivisena.\nKeskeytä [%1$s]:lla",
   "ponder.ui.associated": "Samankaltaiset pohdinnat",
   "ponder.ui.close": "Sulje",

--- a/Common/src/main/resources/assets/ponder/lang/fr_fr.json
+++ b/Common/src/main/resources/assets/ponder/lang/fr_fr.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Maintenir [%1$s] pour y réfléchir",
   "ponder.ui.subject": "Sujet de cette scène",
   "ponder.ui.pondering": "Réflexion à propos de...",
+  "ponder.ui.pondering_tag": "Réflexion à propos de...",
   "ponder.ui.identify_mode": "Mode identification actif.\nReprendre avec [%1$s]",
   "ponder.ui.associated": "Entrées associées",
   "ponder.ui.close": "Fermer",

--- a/Common/src/main/resources/assets/ponder/lang/hu_hu.json
+++ b/Common/src/main/resources/assets/ponder/lang/hu_hu.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Töprengj a [%1$s] nyomva tartásával",
   "ponder.ui.subject": "A jelenet tárgya",
   "ponder.ui.pondering": "Töprengsz a...",
+  "ponder.ui.pondering_tag": "Töprengsz a...",
   "ponder.ui.identify_mode": "Azonosítási mód aktív.\n[%1$s] - Szünet feloldása",
   "ponder.ui.associated": "Kapcsolódó témák",
   "ponder.ui.close": "Bezárás",

--- a/Common/src/main/resources/assets/ponder/lang/it_it.json
+++ b/Common/src/main/resources/assets/ponder/lang/it_it.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Tieni premuto [%1$s] per Riflettere",
   "ponder.ui.subject": "Soggetto della scena",
   "ponder.ui.pondering": "Riflessione riguardante...",
+  "ponder.ui.pondering_tag": "Riflessione riguardante...",
   "ponder.ui.identify_mode": "Modalità Approfondimento attiva.\nRiprendi con [%1$s]",
   "ponder.ui.associated": "Voci correlate",
   "ponder.ui.close": "Chiudi",

--- a/Common/src/main/resources/assets/ponder/lang/ja_jp.json
+++ b/Common/src/main/resources/assets/ponder/lang/ja_jp.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "[%1$s] 長押しで思案画面を開く",
   "ponder.ui.subject": "このシーンの主題",
   "ponder.ui.pondering": "思案中...",
+  "ponder.ui.pondering_tag": "思案中...",
   "ponder.ui.identify_mode": "確認モードになっています。\n [%1$s] で一時停止を解除",
   "ponder.ui.associated": "関連項目",
   "ponder.ui.close": "閉じる",

--- a/Common/src/main/resources/assets/ponder/lang/ko_kr.json
+++ b/Common/src/main/resources/assets/ponder/lang/ko_kr.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "[%1$s]키를 눌러 분석하기",
   "ponder.ui.subject": "분석의 주제",
   "ponder.ui.pondering": "분석 중입니다...",
+  "ponder.ui.pondering_tag": "분석 중입니다...",
   "ponder.ui.identify_mode": "탐색모드가 활성화되어 있습니다. \n[%1$s]을(를) 눌러 중지합니다.",
   "ponder.ui.associated": "연관된 항목들",
   "ponder.ui.close": "닫기",

--- a/Common/src/main/resources/assets/ponder/lang/lzh.json
+++ b/Common/src/main/resources/assets/ponder/lang/lzh.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "押 [%1$s] 以格物",
   "ponder.ui.subject": "所格之物",
   "ponder.ui.pondering": "格物……",
+  "ponder.ui.pondering_tag": "格物……",
   "ponder.ui.identify_mode": "塊名已示\n押 [%1$s] 以继之",
   "ponder.ui.close": "畢",
   "ponder.ui.identify": "示塊名",

--- a/Common/src/main/resources/assets/ponder/lang/nl_nl.json
+++ b/Common/src/main/resources/assets/ponder/lang/nl_nl.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Houd [%1$s] ingedrukt om Na te Denken",
   "ponder.ui.subject": "Onderwerp van deze scène",
   "ponder.ui.pondering": "Onderzoeken over...",
+  "ponder.ui.pondering_tag": "Onderzoeken over...",
   "ponder.ui.identify_mode": "Identificeringsmodus actief.\nHervatten met [%1$s]",
   "ponder.ui.associated": "Gerelateerde Vermeldingen",
   "ponder.ui.close": "Sluiten",

--- a/Common/src/main/resources/assets/ponder/lang/no_no.json
+++ b/Common/src/main/resources/assets/ponder/lang/no_no.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Hold [%1$s] for å undre",
   "ponder.ui.subject": "Emnet for denne scenen",
   "ponder.ui.pondering": "Undrer om...",
+  "ponder.ui.pondering_tag": "Undrer om...",
   "ponder.ui.identify_mode": "Identifiseringsmodus aktiv.\nFortsett avspilling med [%1$s]",
   "ponder.ui.associated": "Tilknyttede emner",
   "ponder.ui.close": "Lukk",

--- a/Common/src/main/resources/assets/ponder/lang/pl_pl.json
+++ b/Common/src/main/resources/assets/ponder/lang/pl_pl.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Przytrzymaj [%1$s], aby przeanalizować",
   "ponder.ui.subject": "Temat tej sceny",
   "ponder.ui.pondering": "Temat analizy:",
+  "ponder.ui.pondering_tag": "Temat analizy:",
   "ponder.ui.identify_mode": "Tryb identyfikacji aktywny. Naciśnij [%1$s], aby wyłączyć",
   "ponder.ui.associated": "Powiązane hasła",
   "ponder.ui.close": "Zamknij",

--- a/Common/src/main/resources/assets/ponder/lang/pt_br.json
+++ b/Common/src/main/resources/assets/ponder/lang/pt_br.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Segure [%1$s] para Ponderar",
   "ponder.ui.subject": "Sujeito desta cena",
   "ponder.ui.pondering": "Ponderando sobre...",
+  "ponder.ui.pondering_tag": "Ponderando sobre...",
   "ponder.ui.identify_mode": "Modo de identificação ativo.\nRetomar com [%1$s]",
   "ponder.ui.associated": "Entradas associadas",
   "ponder.ui.close": "Fechar",

--- a/Common/src/main/resources/assets/ponder/lang/ro_ro.json
+++ b/Common/src/main/resources/assets/ponder/lang/ro_ro.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Ține apăsat [%1$s] pentru a chibzui",
   "ponder.ui.subject": "Subiectul acestei scene",
   "ponder.ui.pondering": "Chibzuind despre...",
+  "ponder.ui.pondering_tag": "Chibzuind despre...",
   "ponder.ui.identify_mode": "Mod de identificare activ.\nReia cu [%1$s]",
   "ponder.ui.associated": "Intrări asociate",
   "ponder.ui.close": "Închide",

--- a/Common/src/main/resources/assets/ponder/lang/ru_ru.json
+++ b/Common/src/main/resources/assets/ponder/lang/ru_ru.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Удерживайте [%1$s] для размышления",
   "ponder.ui.subject": "Тема этой сцены",
   "ponder.ui.pondering": "Размышляем над...",
+  "ponder.ui.pondering_tag": "Категория:",
   "ponder.ui.identify_mode": "Режим идентификации включён.\nСнять паузу: [%1$s]",
   "ponder.ui.associated": "Связанные сцены",
   "ponder.ui.close": "Закрыть",

--- a/Common/src/main/resources/assets/ponder/lang/sv_se.json
+++ b/Common/src/main/resources/assets/ponder/lang/sv_se.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Tryck [%1$s] för att visualisera",
   "ponder.ui.subject": "Scenämne",
   "ponder.ui.pondering": "Visualiserar...",
+  "ponder.ui.pondering_tag": "Visualiserar...",
   "ponder.ui.identify_mode": "Identifieringsläge aktivt.\nÅteruppta med [%1$s]",
   "ponder.ui.associated": "Tillhörande artiklar",
   "ponder.ui.close": "Stäng",

--- a/Common/src/main/resources/assets/ponder/lang/th_th.json
+++ b/Common/src/main/resources/assets/ponder/lang/th_th.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "กด [%1$s] ค้างเพื่อดูตัวอย่างการใช้งาน",
   "ponder.ui.subject": "เนื้อหาหลักของฉากนี้",
   "ponder.ui.pondering": "ตัวอย่างการใช้งานเกี่ยวกับ...",
+  "ponder.ui.pondering_tag": "ตัวอย่างการใช้งานเกี่ยวกับ...",
   "ponder.ui.identify_mode": "โหมดระบุวัตถุในฉากเปิดอยู่\nกด [%1$s] เพื่อเล่นฉากต่อ",
   "ponder.ui.associated": "หัวข้อที่เกี่ยวข้อง",
   "ponder.ui.close": "ปิดฉาก",

--- a/Common/src/main/resources/assets/ponder/lang/tok.json
+++ b/Common/src/main/resources/assets/ponder/lang/tok.json
@@ -1,6 +1,7 @@
 {
   "ponder.ui.hold_to_ponder": "kama sona la o awen luka e [%1$s]",
   "ponder.ui.pondering": "sina kama sona e ni:",
+  "ponder.ui.pondering_tag": "sina kama sona e ni:",
   "ponder.ui.identify_mode": "nasin sona li lon.\no open kepeken [%1$s]",
   "ponder.ui.associated": "toki poka",
   "ponder.ui.close": "pini",

--- a/Common/src/main/resources/assets/ponder/lang/tr_tr.json
+++ b/Common/src/main/resources/assets/ponder/lang/tr_tr.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "İncelemek için [%1$s] Basılı Tut",
   "ponder.ui.subject": "Bu sahnenin konusu",
   "ponder.ui.pondering": "İnceleniyor...",
+  "ponder.ui.pondering_tag": "İnceleniyor...",
   "ponder.ui.identify_mode": "Tanımlama modu etkin.\n[%1$s] ile durdurun",
   "ponder.ui.associated": "Bağlantılı Girdiler",
   "ponder.ui.close": "Kapat",

--- a/Common/src/main/resources/assets/ponder/lang/uk_ua.json
+++ b/Common/src/main/resources/assets/ponder/lang/uk_ua.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "Утримуйте [%1$s], щоб обдумати",
   "ponder.ui.subject": "Об’єкт цієї сцени",
   "ponder.ui.pondering": "Тема роздуму",
+  "ponder.ui.pondering_tag": "Тема роздуму",
   "ponder.ui.identify_mode": "Режим розпізнавання увімкнено.\nНатисніть [%1$s], щоби продовжити",
   "ponder.ui.associated": "Пов’язані записи",
   "ponder.ui.close": "Закрити",

--- a/Common/src/main/resources/assets/ponder/lang/vi_vn.json
+++ b/Common/src/main/resources/assets/ponder/lang/vi_vn.json
@@ -1,6 +1,7 @@
 {
   "ponder.ui.hold_to_ponder": "Giữ [%1$s] để xem chỉ dẫn",
   "ponder.ui.pondering": "Chỉ dẫn về...",
+  "ponder.ui.pondering_tag": "Chỉ dẫn về...",
   "ponder.ui.identify_mode": "Đã bật chế độ tìm hiểu.\nTắt tạm dừng bằng [%1$s]",
   "ponder.ui.associated": "Các khối liên quan",
   "ponder.ui.close": "Đóng",

--- a/Common/src/main/resources/assets/ponder/lang/zh_cn.json
+++ b/Common/src/main/resources/assets/ponder/lang/zh_cn.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "按住 [%1$s] 开始思索",
   "ponder.ui.subject": "情景主题",
   "ponder.ui.pondering": "思索……",
+  "ponder.ui.pondering_tag": "思索……",
   "ponder.ui.identify_mode": "显示方块名称已启用\n按 [%1$s] 继续思索",
   "ponder.ui.associated": "关联词条",
   "ponder.ui.close": "思索结束",

--- a/Common/src/main/resources/assets/ponder/lang/zh_tw.json
+++ b/Common/src/main/resources/assets/ponder/lang/zh_tw.json
@@ -2,6 +2,7 @@
   "ponder.ui.hold_to_ponder": "按住 [%1$s] 來查看此物品的教學",
   "ponder.ui.subject": "本場景的主題",
   "ponder.ui.pondering": "有關於…",
+  "ponder.ui.pondering_tag": "有關於…",
   "ponder.ui.identify_mode": "暫停模式已啟動\n按 [%1$s] 來取消暫停模式",
   "ponder.ui.associated": "相關物品",
   "ponder.ui.close": "關閉",


### PR DESCRIPTION
Fixes https://github.com/Creators-of-Create/Ponder/issues/49 by introducing 'ponder.ui.pondering_tag': a separate string for "Pondering about..." Ponder Categories (Tags), for the sake of compatibility with languages that utilize the word cases system; and adds this string to all languages (excluding ones that don't have 'ponder.ui.pondering'), as well as finally fixes the issue in `ru_ru.json` that started it all.