### PR TITLE
Support for string config

### DIFF
--- a/common/src/main/java/net/createmod/catnip/net/packets/ServerboundConfigPacket.java
+++ b/common/src/main/java/net/createmod/catnip/net/packets/ServerboundConfigPacket.java
@@ -65,6 +65,8 @@ public class ServerboundConfigPacket<T> implements ServerboundPacketPayload {
 	}
 
 	public String serialize(T value) {
+		if(value instanceof String str)
+			return str;
 		if (value instanceof Boolean)
 			return Boolean.toString((Boolean) value);
 		if (value instanceof Enum<?>)
@@ -80,6 +82,8 @@ public class ServerboundConfigPacket<T> implements ServerboundPacketPayload {
 	}
 
 	public static Object deserialize(Object type, String sValue) {
+		if(type instanceof String)
+			return sValue;
 		if (type instanceof Boolean)
 			return Boolean.parseBoolean(sValue);
 		if (type instanceof Enum<?>)

--- a/common/src/main/java/net/createmod/catnip/net/packets/ServerboundConfigPacket.java
+++ b/common/src/main/java/net/createmod/catnip/net/packets/ServerboundConfigPacket.java
@@ -65,8 +65,6 @@ public class ServerboundConfigPacket<T> implements ServerboundPacketPayload {
 	}
 
 	public String serialize(T value) {
-		if(value instanceof String str)
-			return str;
 		if (value instanceof Boolean)
 			return Boolean.toString((Boolean) value);
 		if (value instanceof Enum<?>)
@@ -77,13 +75,13 @@ public class ServerboundConfigPacket<T> implements ServerboundPacketPayload {
 			return Float.toString((Float) value);
 		if (value instanceof Double)
 			return Double.toString((Double) value);
+		if (value instanceof String str)
+			return str;
 
 		throw new IllegalArgumentException("unknown type " + value + ": " + value.getClass().getSimpleName());
 	}
 
 	public static Object deserialize(Object type, String sValue) {
-		if(type instanceof String)
-			return sValue;
 		if (type instanceof Boolean)
 			return Boolean.parseBoolean(sValue);
 		if (type instanceof Enum<?>)
@@ -94,6 +92,8 @@ public class ServerboundConfigPacket<T> implements ServerboundPacketPayload {
 			return Float.parseFloat(sValue);
 		if (type instanceof Double)
 			return Double.parseDouble(sValue);
+		if (type instanceof String)
+			return sValue;
 
 		throw new IllegalArgumentException("unknown type " + type + ": " + type.getClass().getSimpleName());
 	}


### PR DESCRIPTION
I know that create & ponder do not have any String config value, but since catnip allows you to open other mod's config files, String values should also be supported. Without this PR, having any string value results in a crash when the value is modified