### PR TITLE
Port Ponder to Minecraft 26.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     agent any
 
     tools {
-        jdk "jdk-21"
+        jdk "jdk-25"
     }
 
     stages {

--- a/build-logic/src/main/kotlin/configure-platform.gradle.kts
+++ b/build-logic/src/main/kotlin/configure-platform.gradle.kts
@@ -1,4 +1,23 @@
 import net.createmod.pondergradle.nullability.PackageInfosExtension
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.credentials.PasswordCredentials
+import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.plugins.BasePluginExtension
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.jvm.tasks.Jar
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.language.jvm.tasks.ProcessResources
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.getByName
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.withType
 
 // convention plugin to apply to platform subprojects.
 
@@ -13,34 +32,40 @@ plugins.apply("setup-git-hash")
 
 // set up name and group based on parent project, ex. net.createmod.ponder:ponder-fabric
 val modName: String = parent!!.name
-base.archivesName = "$modName-$name"
+val archiveName = "$modName-$name"
+extensions.configure<BasePluginExtension>("base") {
+    archivesName.set(archiveName)
+}
 group = "net.createmod.$modName"
 
 // keep version synchronized with the root project
 version = rootProject.version
 
 repositories {
-    mavenLocal() // TODO: remove when Flywheel is pushed
+    if (providers.gradleProperty("ponder.useMavenLocal").isPresent) {
+        mavenLocal()
+    }
+    maven("https://maven.neoforged.net/releases") // NeoForge API
     maven("https://maven.createmod.net") // Flywheel
     maven("https://raw.githubusercontent.com/Fuzss/modresources/main/maven/") // Forge Config API Port
 }
 
-java {
+extensions.configure<JavaPluginExtension>("java") {
     withSourcesJar()
-    toolchain.languageVersion = JavaLanguageVersion.of(25)
+    toolchain.languageVersion.set(JavaLanguageVersion.of(25))
 }
 
 tasks.withType<Jar> {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     // copy the license file into every built jar
     from(rootProject.file("LICENSE"))
+    exclude("net/createmod/catnip/net/base/package-info.java")
 }
 
-val libs: VersionCatalog = versionCatalogs.named("libs")
+val libs: VersionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
 fun versionOf(name: String): String {
     val version = libs.findVersion(name).get().toString()
 
-    // thank you fabric loader for mangling all non-release versions
-    // FIXME remove when on full 26.1
     if (name == "minecraft" && project.name == "fabric")
         return version
             .replace("snapshot-", "alpha.")
@@ -54,7 +79,7 @@ val authors = findProperty("authors") as String
 val contributors = findProperty("contributors") as String
 
 // expand placeholders in metadata files
-tasks.processResources {
+tasks.named<ProcessResources>("processResources") {
     val properties = mapOf(
         "version" to project.version,
         "group" to project.group,
@@ -77,9 +102,10 @@ tasks.processResources {
 
 // don't publish the testmod
 if (parent!!.name != "testmod") {
-    publishing {
+    extensions.configure<PublishingExtension>("publishing") {
         publications.create<MavenPublication>("mavenJava") {
-            from(components["java"])
+            artifactId = archiveName
+            from(components.getByName("java"))
         }
 
         repositories {
@@ -101,23 +127,33 @@ loom?.javaClass?.getMethod("splitEnvironmentSourceSets")?.run {
     plugins.apply("register-client-jar")
 }
 
+val sourceSets = extensions.getByType<SourceSetContainer>()
+
 // generate package-infos for the main (and client, if present) sourceSet(s)
 extensions.getByType<PackageInfosExtension>().sources(sourceSets.named { it == "main" || it == "client" })
 
 if (name != "common") {
     tasks.withType<Jar> {
         dependsOn(project(":common").tasks.named("generatePackageInfos"))
+        dependsOn(project(":common").tasks.matching { it.name == "generateClientPackageInfos" })
+        if (parent?.name == "catnip") {
+            dependsOn(project(":catnip:common").tasks.named("generatePackageInfos"))
+            dependsOn(project(":catnip:common").tasks.matching { it.name == "generateClientPackageInfos" })
+        }
     }
-}
 
-// FIXME: temporary hack - disable everything config-related
-tasks.withType<JavaCompile> {
-    exclude("**/config")
-    exclude("**/ConfigCommand.java")
-    exclude("**/ConfigPathArgument.java")
-    exclude("**/CClient.java")
-    exclude("**/PonderConfig.java")
-    exclude("**/ConfirmationScreen.java")
+    tasks.withType<JavaCompile> {
+        dependsOn(project(":common").tasks.named("generatePackageInfos"))
+        dependsOn(project(":common").tasks.matching { it.name == "generateClientPackageInfos" })
+        dependsOn(project(":common").tasks.matching { it.name == "compileClientJava" })
+        dependsOn(project(":common").tasks.matching { it.name == "processClientResources" })
+        if (parent?.name == "catnip") {
+            dependsOn(project(":catnip:common").tasks.named("generatePackageInfos"))
+            dependsOn(project(":catnip:common").tasks.matching { it.name == "generateClientPackageInfos" })
+            dependsOn(project(":catnip:common").tasks.matching { it.name == "compileClientJava" })
+            dependsOn(project(":catnip:common").tasks.matching { it.name == "processClientResources" })
+        }
+    }
 }
 
 when (name) {

--- a/build-logic/src/main/kotlin/consume-common-merged.gradle.kts
+++ b/build-logic/src/main/kotlin/consume-common-merged.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.file.DuplicatesStrategy
+
 val compileOnly: Configuration by configurations.getting
 val commonJava: Configuration by configurations.dependencyScope("commonJava")
 val commonResources: Configuration by configurations.dependencyScope("commonResources")
@@ -21,9 +23,18 @@ val resolvableCommonResources: Configuration by configurations.resolvable("resol
     extendsFrom(commonResources)
 }
 
+val filteredCommonJava = resolvableCommonJava.asFileTree.matching {
+    exclude("**/generatedPackageInfos/net/createmod/catnip/net/base/package-info.java")
+    exclude("**/generatedPackageInfos/net/createmod/catnip/api/platform/package-info.java")
+    exclude("**/generatedPackageInfos/net/createmod/catnip/api/client/package-info.java")
+    exclude("net/createmod/catnip/net/base/package-info.java")
+    exclude("net/createmod/catnip/api/platform/package-info.java")
+    exclude("net/createmod/catnip/api/client/package-info.java")
+}
+
 tasks.named<JavaCompile>("compileJava") {
     dependsOn(resolvableCommonJava)
-    source(resolvableCommonJava)
+    source(filteredCommonJava)
 }
 
 tasks.named<ProcessResources>("processResources") {
@@ -32,6 +43,7 @@ tasks.named<ProcessResources>("processResources") {
 }
 
 tasks.named<Jar>("sourcesJar") {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     dependsOn(resolvableCommonJava, resolvableCommonResources)
-    from(resolvableCommonJava, resolvableCommonResources)
+    from(filteredCommonJava, resolvableCommonResources)
 }

--- a/build-logic/src/main/kotlin/consume-common-split.gradle.kts
+++ b/build-logic/src/main/kotlin/consume-common-split.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.file.DuplicatesStrategy
+
 val compileOnly: Configuration by configurations.getting
 val clientCompileOnly: Configuration by configurations.getting
 
@@ -36,14 +38,32 @@ val resolvableCommonClientResources: Configuration by configurations.resolvable(
     extendsFrom(commonClientResources)
 }
 
+val filteredCommonMainJava = resolvableCommonMainJava.asFileTree.matching {
+    exclude("**/generatedPackageInfos/net/createmod/catnip/net/base/package-info.java")
+    exclude("**/generatedPackageInfos/net/createmod/catnip/api/platform/package-info.java")
+    exclude("**/generatedPackageInfos/net/createmod/catnip/api/client/package-info.java")
+    exclude("net/createmod/catnip/net/base/package-info.java")
+    exclude("net/createmod/catnip/api/platform/package-info.java")
+    exclude("net/createmod/catnip/api/client/package-info.java")
+}
+
+val filteredCommonClientJava = resolvableCommonClientJava.asFileTree.matching {
+    exclude("**/generatedPackageInfos/net/createmod/catnip/net/base/package-info.java")
+    exclude("**/generatedPackageInfos/net/createmod/catnip/api/platform/package-info.java")
+    exclude("**/generatedPackageInfos/net/createmod/catnip/api/client/package-info.java")
+    exclude("net/createmod/catnip/net/base/package-info.java")
+    exclude("net/createmod/catnip/api/platform/package-info.java")
+    exclude("net/createmod/catnip/api/client/package-info.java")
+}
+
 tasks.named<JavaCompile>("compileJava") {
     dependsOn(resolvableCommonMainJava)
-    source(resolvableCommonMainJava)
+    source(filteredCommonMainJava)
 }
 
 tasks.named<JavaCompile>("compileClientJava") {
     dependsOn(resolvableCommonClientJava)
-    source(resolvableCommonClientJava)
+    source(filteredCommonClientJava)
 }
 
 tasks.named<ProcessResources>("processResources") {
@@ -57,6 +77,7 @@ tasks.named<ProcessResources>("processClientResources") {
 }
 
 tasks.named<Jar>("sourcesJar") {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     dependsOn(resolvableCommonMainJava, resolvableCommonMainResources)
-    from(resolvableCommonMainJava, resolvableCommonMainResources)
+    from(filteredCommonMainJava, resolvableCommonMainResources)
 }

--- a/catnip/common/build.gradle.kts
+++ b/catnip/common/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
 dependencies {
     minecraft(libs.minecraft)
     compileOnly(libs.bundles.mixin)
+    compileOnlyApi(libs.bundles.neoforge.config)
+    clientCompileOnly(libs.bundles.neoforge.config)
 }
 
 loom {

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/config/BaseConfigScreen.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/config/BaseConfigScreen.java
@@ -6,23 +6,12 @@ import java.util.function.UnaryOperator;
 
 import org.jspecify.annotations.Nullable;
 
-import com.mojang.blaze3d.platform.InputConstants;
-
-import net.createmod.catnip.api.client.gui.ScreenOpener;
 import net.createmod.catnip.api.client.gui.UIRenderHelper;
 import net.createmod.catnip.api.client.gui.element.FadableScreenElement;
-import net.createmod.catnip.api.client.gui.element.TextStencilElement;
-import net.createmod.catnip.api.client.gui.texture.CatnipGuiTextures;
 import net.createmod.catnip.api.client.gui.widget.AbstractSimiWidget;
-import net.createmod.catnip.api.client.gui.widget.BoxWidget;
-import net.createmod.catnip.api.client.lang.FontHelper;
-import net.createmod.catnip.api.client.lang.FontHelper.Palette;
 import net.createmod.catnip.api.config.ConfigHelper;
-import net.createmod.catnip.api.platform.services.PlatformHelper;
-import net.createmod.catnip.api.theme.Color;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.input.KeyEvent;
 import net.minecraft.network.chat.Component;
 
 import net.neoforged.fml.config.ModConfig;
@@ -30,36 +19,9 @@ import net.neoforged.neoforge.common.ModConfigSpec;
 
 public class BaseConfigScreen extends ConfigScreen {
 
-	public static final Color COLOR_TITLE_A = new Color(0xff_c69fbc).setImmutable();
-	public static final Color COLOR_TITLE_B = new Color(0xff_f6b8bb).setImmutable();
-	public static final Color COLOR_TITLE_C = new Color(0xff_fbf994).setImmutable();
-
-	public static final FadableScreenElement DISABLED_RENDERER = (ms, width, height, alpha) -> UIRenderHelper.angledGradient(ms, 0, 0, height / 2, height, width, AbstractSimiWidget.COLOR_DISABLED);
 	private static final Map<String, UnaryOperator<BaseConfigScreen>> DEFAULTS = new HashMap<>();
-
-	/**
-	 * If you want to change the config labels, add a default action here.
-	 * Make sure you call either {@link #withSpecs(ModConfigSpec, ModConfigSpec, ModConfigSpec)}
-	 * or {@link #searchForConfigSpecs()}
-	 *
-	 * @param modID the modID of your addon/mod
-	 */
-	public static void setDefaultActionFor(String modID, UnaryOperator<BaseConfigScreen> transform) {
-		DEFAULTS.put(modID, transform);
-	}
-
-	@Nullable
-	BoxWidget clientConfigWidget;
-	@Nullable
-	BoxWidget commonConfigWidget;
-	@Nullable
-	BoxWidget serverConfigWidget;
-	@Nullable
-	BoxWidget goBack;
-	@Nullable
-	BoxWidget others;
-	@Nullable
-	BoxWidget title;
+	public static final FadableScreenElement DISABLED_RENDERER = (graphics, width, height, alpha) ->
+		UIRenderHelper.angledGradient(graphics, 90, width / 2, -2, width + 4, height + 4, AbstractSimiWidget.COLOR_DISABLED);
 
 	@Nullable
 	ModConfigSpec clientSpec;
@@ -71,7 +33,6 @@ public class BaseConfigScreen extends ConfigScreen {
 	String commonButtonLabel = "Common Config";
 	String serverButtonLabel = "Server Config";
 	String modID;
-	protected boolean returnOnClose;
 
 	public BaseConfigScreen(@Nullable Screen parent, String modID) {
 		super(parent);
@@ -79,34 +40,32 @@ public class BaseConfigScreen extends ConfigScreen {
 
 		if (DEFAULTS.containsKey(modID))
 			DEFAULTS.get(modID).apply(this);
-		else {
-			this.searchForConfigSpecs();
-		}
+		else
+			searchForConfigSpecs();
 	}
 
-	/**
-	 * If you have static references to your Configs or ConfigSpecs (like Create does in AllConfigs),
-	 * please use {@link #withSpecs(ModConfigSpec, ModConfigSpec, ModConfigSpec)} instead
-	 */
+	public static void setDefaultActionFor(String modID, UnaryOperator<BaseConfigScreen> transform) {
+		DEFAULTS.put(modID, transform);
+	}
+
 	public BaseConfigScreen searchForConfigSpecs() {
-		if (!net.createmod.catnip.api.config.ConfigHelper.hasAnyForgeConfig(this.modID)) {
+		if (!ConfigHelper.hasAnyForgeConfig(modID))
 			return this;
-		}
 
 		try {
-			clientSpec = net.createmod.catnip.api.config.ConfigHelper.findModConfigSpecFor(ModConfig.Type.CLIENT, modID);
+			clientSpec = ConfigHelper.findModConfigSpecFor(ModConfig.Type.CLIENT, modID);
 		} catch (ClassCastException | NullPointerException e) {
 			ConfigHelper.LOGGER.debug("Unable to find ClientConfigSpec for mod: {}", modID);
 		}
 
 		try {
-			commonSpec = net.createmod.catnip.api.config.ConfigHelper.findModConfigSpecFor(ModConfig.Type.COMMON, modID);
+			commonSpec = ConfigHelper.findModConfigSpecFor(ModConfig.Type.COMMON, modID);
 		} catch (ClassCastException | NullPointerException e) {
 			ConfigHelper.LOGGER.debug("Unable to find CommonConfigSpec for mod: {}", modID);
 		}
 
 		try {
-			serverSpec = net.createmod.catnip.api.config.ConfigHelper.findModConfigSpecFor(ModConfig.Type.SERVER, modID);
+			serverSpec = ConfigHelper.findModConfigSpecFor(ModConfig.Type.SERVER, modID);
 		} catch (ClassCastException | NullPointerException e) {
 			ConfigHelper.LOGGER.debug("Unable to find ServerConfigSpec for mod: {}", modID);
 		}
@@ -124,119 +83,27 @@ public class BaseConfigScreen extends ConfigScreen {
 	public BaseConfigScreen withButtonLabels(@Nullable String client, @Nullable String common, @Nullable String server) {
 		if (client != null)
 			clientButtonLabel = client;
-
 		if (common != null)
 			commonButtonLabel = common;
-
 		if (server != null)
 			serverButtonLabel = server;
-
 		return this;
 	}
 
 	@Override
 	protected void init() {
 		super.init();
-		returnOnClose = true;
-
-		TextStencilElement clientText = new TextStencilElement(font, Component.translatable("catnip.ui.client_config_button_label")).centered(true, true);
-		addRenderableWidget(clientConfigWidget = new BoxWidget(width / 2 - 100, height / 2 - 15 - 30, 200, 16).showingElement(clientText));
-
-		if (clientSpec != null) {
-			clientConfigWidget.withCallback(() -> linkTo(new SubMenuConfigScreen(this, ModConfig.Type.CLIENT, clientSpec)));
-			clientText.withElementRenderer(BoxWidget.gradientFactory.apply(clientConfigWidget));
-		} else {
-			clientConfigWidget.active = false;
-			clientConfigWidget.updateGradientFromState();
-			clientText.withElementRenderer(DISABLED_RENDERER);
-		}
-
-		TextStencilElement commonText = new TextStencilElement(font, Component.translatable("catnip.ui.common_config_button_label")).centered(true, true);
-		addRenderableWidget(commonConfigWidget = new BoxWidget(width / 2 - 100, height / 2 - 15, 200, 16).showingElement(commonText));
-
-		if (commonSpec != null) {
-			commonConfigWidget.withCallback(() -> linkTo(new SubMenuConfigScreen(this, ModConfig.Type.COMMON, commonSpec)));
-			commonText.withElementRenderer(BoxWidget.gradientFactory.apply(commonConfigWidget));
-		} else {
-			commonConfigWidget.active = false;
-			commonConfigWidget.updateGradientFromState();
-			commonText.withElementRenderer(DISABLED_RENDERER);
-		}
-
-		TextStencilElement serverText = new TextStencilElement(font, Component.translatable("catnip.ui.server_config_button_label")).centered(true, true);
-		addRenderableWidget(serverConfigWidget = new BoxWidget(width / 2 - 100, height / 2 - 15 + 30, 200, 16).showingElement(serverText));
-
-		if (serverSpec == null) {
-			serverConfigWidget.active = false;
-			serverConfigWidget.updateGradientFromState();
-			serverText.withElementRenderer(DISABLED_RENDERER);
-		} else if (minecraft.level == null) {
-			serverText.withElementRenderer(DISABLED_RENDERER);
-			serverConfigWidget.getToolTip()
-				.add(Component.translatable("catnip.ui.server_config_unavailable"));
-			serverConfigWidget.getToolTip()
-				.addAll(FontHelper.cutTextComponent(
-					Component.translatable("catnip.ui.server_config_unavailable_tooltip"),
-					Palette.ALL_GRAY));
-		} else {
-			serverConfigWidget.withCallback(() -> linkTo(new SubMenuConfigScreen(this, ModConfig.Type.SERVER, serverSpec)));
-			serverText.withElementRenderer(BoxWidget.gradientFactory.apply(serverConfigWidget));
-		}
-
-		TextStencilElement titleText = new TextStencilElement(font, PlatformHelper.INSTANCE.getModDisplayName(modID))
-			.centered(true, true)
-			.withElementRenderer((ms, w, h, alpha) -> {
-				UIRenderHelper.angledGradient(ms, 0, 0, h / 2, h, w / 2, COLOR_TITLE_A, COLOR_TITLE_B);
-				UIRenderHelper.angledGradient(ms, 0, w / 2, h / 2, h, w / 2, COLOR_TITLE_B, COLOR_TITLE_C);
-			});
-		int boxWidth = width + 10;
-		int boxHeight = 39;
-		int boxPadding = 4;
-		title = new BoxWidget(-5, height / 2 - 110, boxWidth, boxHeight)
-			//.withCustomBackground(new Color(0x20_000000, true))
-			.<BoxWidget>setActive(false)
-			.withBorderColors(AbstractSimiWidget.COLOR_IDLE)
-			.withPadding(0, boxPadding)
-			.rescaleElement(boxWidth / 2f, (boxHeight - 2 * boxPadding) / 2f)//double the text size by telling it the element is only half as big as the available space
-			.showingElement(titleText.at(0, 7));
-
-		addRenderableWidget(title);
-
-
-		ConfigScreen.modID = this.modID;
-
-		goBack = new BoxWidget(width / 2 - 134, height / 2, 20, 20).withPadding(2, 2)
-			.withCallback(() -> linkTo(parent));
-		goBack.showingElement(CatnipGuiTextures.ICON_CONFIG_BACK.asStencil()
-			.withElementRenderer(BoxWidget.gradientFactory.apply(goBack)));
-		goBack.getToolTip()
-			.add(Component.translatable("catnip.ui.go_back_button"));
-		addRenderableWidget(goBack);
-
-		TextStencilElement othersText = new TextStencilElement(font, Component.translatable("catnip.ui.other_mods_config_button_label")).centered(true, true);
-		others = new BoxWidget(width / 2 - 100, height / 2 - 15 + 90, 200, 16).showingElement(othersText);
-		othersText.withElementRenderer(BoxWidget.gradientFactory.apply(others));
-		others.withCallback(() -> linkTo(new ConfigModListScreen(this)));
-		addRenderableWidget(others);
+		int x = width / 2 - 100;
+		int y = height / 2 - 36;
+		addRenderableWidget(configButton(x, y, clientButtonLabel, clientSpec));
+		addRenderableWidget(configButton(x, y + 24, commonButtonLabel, commonSpec));
+		addRenderableWidget(configButton(x, y + 48, serverButtonLabel, serverSpec));
 	}
 
-	@Override
-	protected void renderWindow(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float partialTicks) {
-		graphics.centeredText(font, Component.translatable("catnip.ui.other_mods_config_title"), width / 2, height / 2 - 105, UIRenderHelper.COLOR_TEXT_STRONG_ACCENT.getFirst().getRGB());
-	}
-
-	private void linkTo(@Nullable Screen screen) {
-		returnOnClose = false;
-		ScreenOpener.open(screen);
-	}
-
-	@Override
-	public boolean keyPressed(KeyEvent keyEvent) {
-		if (super.keyPressed(keyEvent))
-			return true;
-		if (keyEvent.key() == InputConstants.KEY_BACKSPACE) {
-			linkTo(parent);
-		}
-		return false;
+	private Button configButton(int x, int y, String label, @Nullable ModConfigSpec spec) {
+		Button button = Button.builder(Component.literal(label), $ -> {
+		}).bounds(x, y, 200, 20).build();
+		button.active = spec != null;
+		return button;
 	}
 }

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/config/ConfigModListScreen.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/config/ConfigModListScreen.java
@@ -56,8 +56,7 @@ public class ConfigModListScreen extends ConfigScreen {
 
 			return e1.id.compareToIgnoreCase(e2.id);
 		});
-		list.children().clear();
-		list.children().addAll(allEntries);
+		list.setEntries(allEntries);
 
 		goBack = new BoxWidget(width / 2 - listWidth / 2 - 30, height / 2 + 65, 20, 20).withPadding(2, 2)
 			.withCallback(() -> ScreenOpener.open(parent));
@@ -103,11 +102,11 @@ public class ConfigModListScreen extends ConfigScreen {
 		assert list != null;
 		assert this.search != null;
 
-		list.children().clear();
+		list.clearConfigEntries();
 		//todo include display names in search
 		for (ModEntry modEntry : allEntries) {
 			if (modEntry.id.contains(search.toLowerCase(Locale.ROOT))) {
-				list.children().add(modEntry);
+				list.addConfigEntry(modEntry);
 			}
 		}
 

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/config/ConfigScreen.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/config/ConfigScreen.java
@@ -1,24 +1,14 @@
 package net.createmod.catnip.api.client.config;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Locale;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.util.TriConsumer;
-import org.joml.Matrix3x2fStack;
 import org.jspecify.annotations.Nullable;
-import org.lwjgl.opengl.GL30;
 
-import com.mojang.blaze3d.opengl.GlStateManager;
-
-import net.createmod.catnip.api.animation.Force;
 import net.createmod.catnip.api.animation.PhysicalFloat;
 import net.createmod.catnip.api.client.gui.AbstractSimiScreen;
-import net.createmod.catnip.api.client.gui.element.DelegatedStencilElement;
-import net.createmod.catnip.api.client.gui.element.GuiGameElement;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
@@ -28,17 +18,15 @@ import net.minecraft.world.level.block.state.BlockState;
 public abstract class ConfigScreen extends AbstractSimiScreen {
 
 	public static final Map<String, TriConsumer<Screen, GuiGraphicsExtractor, Float>> backgrounds = new HashMap<>();
-	public static final PhysicalFloat cogSpin = PhysicalFloat.create().withLimit(10f).withDrag(0.3).addForce(new Force.Static(.2f));
 	@Nullable
 	public static String modID = null;
-	@Nullable
-	protected final Screen parent;
+	public static final PhysicalFloat cogSpin = PhysicalFloat.create()
+		.withDrag(0.4)
+		.withLimit(30);
 
 	public static BlockState shadowState = Blocks.POTTED_CRIMSON_ROOTS.defaultBlockState();
-	public static DelegatedStencilElement shadowElement = new DelegatedStencilElement(
-		(graphics, x, y, alpha) -> renderCog(graphics),
-		(graphics, x, y, alpha) -> graphics.fill(-200, -200, 200, 200, 0x60_000000)
-	);
+	@Nullable
+	protected final Screen parent;
 
 	public ConfigScreen(@Nullable Screen parent) {
 		super(Component.empty());
@@ -46,93 +34,33 @@ public abstract class ConfigScreen extends AbstractSimiScreen {
 	}
 
 	@Override
-	public void tick() {
-		super.tick();
-		cogSpin.tick();
-	}
-
-	@Override
-	public void extractBackground(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float partialTick) {
-	}
-
-	@Override
-	protected void extractMenuBackground(GuiGraphicsExtractor graphics, int x, int y, int width, int height) {
-		if (this.minecraft.level != null) {
-			//in game
-			graphics.fill(0, 0, this.width, this.height, 0xb0_282c34);
-		} else {
-			//in menus
-			extractMenuBackground(graphics);
-		}
-
-		shadowElement
-			.at(width * 0.5f, height * 0.5f, 0)
-			.submit(graphics);
-
-		super.extractMenuBackground(graphics, x, y, width, height);
-
-	}
-
-	@Override
-	protected void prepareFrame() {
-		GlStateManager._clear(GL30.GL_STENCIL_BUFFER_BIT | GL30.GL_DEPTH_BUFFER_BIT);
-	}
-	
-	@Override
-	protected void renderWindow(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float partialTicks) {
-	}
-
-	@Override
-	public boolean mouseScrolled(double mouseX, double mouseY, double scrollX, double scrollY) {
-		cogSpin.bump(3, -scrollY * 5);
-
-		return super.mouseScrolled(mouseX, mouseY, scrollX, scrollY);
-	}
-
-	@Override
 	public boolean isPauseScreen() {
 		return true;
 	}
 
-	public static String toHumanReadable(String key) {
-		String s = key.replaceAll("_", " ");
-		s = Arrays.stream(StringUtils.splitByCharacterTypeCamelCase(s)).map(StringUtils::capitalize).collect(Collectors.joining(" "));
-		s = StringUtils.normalizeSpace(s);
-		return s;
-	}
-
-	/**
-	 * By default, ConfigScreens will render the Vanilla Panorama as
-	 * their background when not opened ingame.
-	 * If your mod wants to render something else, please add to the
-	 * {@code backgrounds} Map in this Class with your modID as the key.
-	 */
-	protected void renderMenuBackground(GuiGraphicsExtractor graphics, float partialTicks) {
-		TriConsumer<Screen, GuiGraphics, Float> customBackground = backgrounds.get(modID);
-		if (customBackground != null) {
-			customBackground.accept(this, graphics, partialTicks);
+	@Override
+	public void onClose() {
+		if (parent != null && minecraft != null) {
+			minecraft.gui.setScreen(parent);
 			return;
 		}
-
-		Minecraft.getInstance()
-			.gameRenderer
-			.getPanorama()
-			.render(graphics, this.width, this.height, true);
-
-		graphics.fill(0, 0, this.width, this.height, 0x90_282c34);
+		super.onClose();
 	}
 
-	protected static void renderCog(GuiGraphicsExtractor graphics) {
-		float partialTicks = Minecraft.getInstance().getDeltaTracker().getGameTimeDeltaPartialTick(false);
-		Matrix3x2fStack poseStack = graphics.pose();
-		poseStack.pushMatrix();
+	public static String toHumanReadable(String key) {
+		String text = key.replace('_', ' ').replace('-', ' ');
+		text = text.replaceAll("(?<=[a-z0-9])(?=[A-Z])", " ");
 
-		poseStack.translate(-100, 100);
-		poseStack.scale(200, 200);
-		GuiGameElement.of(shadowState)
-			.rotateBlock(22.5, cogSpin.getValue(partialTicks), 22.5)
-			.submit(graphics);
-
-		poseStack.popMatrix();
+		StringBuilder builder = new StringBuilder();
+		for (String word : text.split("\\s+")) {
+			if (word.isEmpty())
+				continue;
+			if (!builder.isEmpty())
+				builder.append(' ');
+			builder.append(word.substring(0, 1).toUpperCase(Locale.ROOT));
+			if (word.length() > 1)
+				builder.append(word.substring(1).toLowerCase(Locale.ROOT));
+		}
+		return builder.toString();
 	}
 }

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/config/ConfigScreenList.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/config/ConfigScreenList.java
@@ -1,6 +1,8 @@
 package net.createmod.catnip.api.client.config;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -10,7 +12,6 @@ import java.util.Optional;
 import org.jspecify.annotations.Nullable;
 
 import com.mojang.blaze3d.opengl.GlStateManager;
-import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.systems.RenderSystem;
 
 import net.createmod.catnip.api.animation.LerpedFloat;
@@ -45,24 +46,31 @@ public class ConfigScreenList extends ObjectSelectionList<ConfigScreenList.Entry
 	}
 
 	@Override
-	public void render(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float partialTicks) {
+	public void extractWidgetRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float partialTicks) {
 		Color c = new Color(0x60_000000);
 		UIRenderHelper.angledGradient(graphics, 90, getX() + width / 2, getY(), width, 5, c, Color.TRANSPARENT_BLACK);
 		UIRenderHelper.angledGradient(graphics, -90, getX() + width / 2, getBottom(), width, 5, c, Color.TRANSPARENT_BLACK);
 		UIRenderHelper.angledGradient(graphics, 0, getX(), getY() + height / 2, height, 5, c, Color.TRANSPARENT_BLACK);
 		UIRenderHelper.angledGradient(graphics, 180, getRight(), getY() + height / 2, height, 5, c, Color.TRANSPARENT_BLACK);
 
-		super.render(graphics, mouseX, mouseY, partialTicks);
+		super.extractWidgetRenderState(graphics, mouseX, mouseY, partialTicks);
 	}
 
-	@Override
-	protected void renderListItems(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float partialTick) {
-		Window window = minecraft.getWindow();
-		double d0 = window.getGuiScale();
-		// TODO - Check is this still works here
-		RenderSystem.enableScissorForRenderTypeDraws((int) (getX() * d0), (int) (window.getHeight() - (getBottom() * d0)), (int) (this.width * d0), (int) (this.height * d0));
-		super.renderListItems(graphics, mouseX, mouseY, partialTick);
-		RenderSystem.disableScissorForRenderTypeDraws();
+	public void setEntries(Collection<? extends Entry> entries) {
+		clearEntries();
+		entries.forEach(this::addConfigEntry);
+	}
+
+	public void clearConfigEntries() {
+		clearEntries();
+	}
+
+	public void addConfigEntry(Entry entry) {
+		addEntry(entry);
+	}
+
+	public void sortEntries(Comparator<Entry> comparator) {
+		sort(comparator);
 	}
 
 	@Override
@@ -174,6 +182,14 @@ public class ConfigScreenList extends ObjectSelectionList<ConfigScreenList.Entry
 				return false;
 			}
 			return net.createmod.catnip.api.config.ConfigHelper.changes.containsKey(path);
+		}
+
+		@Override
+		public void extractContent(GuiGraphicsExtractor graphics, int mouseX, int mouseY, boolean hovered, float partialTick) {
+			renderContent(graphics, mouseX, mouseY, hovered, partialTick);
+		}
+
+		public void renderContent(GuiGraphicsExtractor graphics, int mouseX, int mouseY, boolean hovered, float partialTick) {
 		}
 	}
 

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/config/SubMenuConfigScreen.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/config/SubMenuConfigScreen.java
@@ -30,15 +30,15 @@ import net.createmod.catnip.api.client.gui.UIRenderHelper;
 import net.createmod.catnip.api.client.gui.element.DelegatedStencilElement;
 import net.createmod.catnip.api.client.gui.widget.AbstractSimiWidget;
 import net.createmod.catnip.api.client.gui.widget.BoxWidget;
+import net.createmod.catnip.api.client.network.ClientNetworkHelper;
 import net.createmod.catnip.api.client.lang.FontHelper;
 import net.createmod.catnip.api.client.lang.FontHelper.Palette;
 import net.createmod.catnip.api.data.Couple;
 import net.createmod.catnip.api.data.Pair;
-import net.createmod.catnip.api.network.NetworkHelper;
 import net.createmod.catnip.api.theme.Color;
-import net.createmod.catnip.config.ui.ConfigScreenList.LabeledEntry;
+import net.createmod.catnip.api.client.config.ConfigScreenList.LabeledEntry;
 import net.createmod.catnip.impl.network.ServerboundConfigPacket;
-import net.createmod.ponder.enums.PonderGuiTextures;
+import net.createmod.catnip.api.client.gui.texture.CatnipGuiTextures;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.events.GuiEventListener;
@@ -77,7 +77,7 @@ public class SubMenuConfigScreen extends ConfigScreen {
 	public static SubMenuConfigScreen find(net.createmod.catnip.api.config.ConfigHelper.ConfigPath path) {
 		ModConfigSpec spec = net.createmod.catnip.api.config.ConfigHelper.findModConfigSpecFor(path.getType(), path.getModID());
 		UnmodifiableConfig values = spec.getValues();
-		net.createmod.catnip.config.ui.BaseConfigScreen base = new BaseConfigScreen(null, path.getModID());
+		net.createmod.catnip.api.client.config.BaseConfigScreen base = new BaseConfigScreen(null, path.getModID());
 		SubMenuConfigScreen screen = new SubMenuConfigScreen(base, "root", path.getType(), spec, values);
 		List<String> remainingPath = Lists.newArrayList(path.getPath());
 
@@ -142,7 +142,7 @@ public class SubMenuConfigScreen extends ConfigScreen {
 
 			if (type == ModConfig.Type.SERVER) {
 				assert ConfigScreen.modID != null;
-				NetworkHelper.INSTANCE.sendToServer(new ServerboundConfigPacket<>(ConfigScreen.modID, path, change.value));
+				ClientNetworkHelper.INSTANCE.sendToServer(new ServerboundConfigPacket<>(ConfigScreen.modID, path, change.value));
 			}
 
 			String command = change.annotations.get("Execute");
@@ -202,7 +202,7 @@ public class SubMenuConfigScreen extends ConfigScreen {
 					.open(this)
 			);
 
-		resetAll.showingElement(PonderGuiTextures.ICON_CONFIG_RESET.asStencil().withElementRenderer(BoxWidget.gradientFactory.apply(resetAll)));
+		resetAll.showingElement(CatnipGuiTextures.ICON_CONFIG_RESET.asStencil().withElementRenderer(BoxWidget.gradientFactory.apply(resetAll)));
 		resetAll.getToolTip().add(Component.translatable("catnip.ui.reset_all_button"));
 		resetAll.getToolTip().addAll(FontHelper.cutTextComponent(Component.translatable("catnip.ui.reset_all_button_tooltip"), Palette.ALL_GRAY));
 
@@ -222,7 +222,7 @@ public class SubMenuConfigScreen extends ConfigScreen {
 
 				addAnnotationsToConfirm(confirm).open(this);
 			});
-		saveChanges.showingElement(PonderGuiTextures.ICON_CONFIG_SAVE.asStencil().withElementRenderer(BoxWidget.gradientFactory.apply(saveChanges)));
+		saveChanges.showingElement(CatnipGuiTextures.ICON_CONFIG_SAVE.asStencil().withElementRenderer(BoxWidget.gradientFactory.apply(saveChanges)));
 		saveChanges.getToolTip().add(Component.translatable("catnip.ui.save_changes_button"));
 		saveChanges.getToolTip().addAll(FontHelper.cutTextComponent(Component.translatable("catnip.ui.save_changes_button_tooltip"), Palette.ALL_GRAY));
 
@@ -241,14 +241,14 @@ public class SubMenuConfigScreen extends ConfigScreen {
 					})
 					.open(this);
 			});
-		discardChanges.showingElement(PonderGuiTextures.ICON_CONFIG_DISCARD.asStencil().withElementRenderer(BoxWidget.gradientFactory.apply(discardChanges)));
+		discardChanges.showingElement(CatnipGuiTextures.ICON_CONFIG_DISCARD.asStencil().withElementRenderer(BoxWidget.gradientFactory.apply(discardChanges)));
 		discardChanges.getToolTip().add(Component.translatable("catnip.ui.discard_changes_button"));
 		discardChanges.getToolTip().addAll(FontHelper.cutTextComponent(Component.translatable("catnip.ui.discard_changes_button_tooltip"), Palette.ALL_GRAY));
 
 		goBack = new BoxWidget(listL - 30, yCenter + 65, 20, 20)
 			.withPadding(2, 2)
 			.withCallback(this::attemptBackstep);
-		goBack.showingElement(PonderGuiTextures.ICON_CONFIG_BACK.asStencil().withElementRenderer(BoxWidget.gradientFactory.apply(goBack)));
+		goBack.showingElement(CatnipGuiTextures.ICON_CONFIG_BACK.asStencil().withElementRenderer(BoxWidget.gradientFactory.apply(goBack)));
 		goBack.getToolTip().add(Component.translatable("catnip.ui.go_back_button"));
 
 		addRenderableWidget(resetAll);
@@ -273,7 +273,7 @@ public class SubMenuConfigScreen extends ConfigScreen {
 			if (obj instanceof AbstractConfig) {
 				SubMenuEntry entry = new SubMenuEntry(this, humanKey, spec, (UnmodifiableConfig) obj);
 				entry.path = key;
-				list.children().add(entry);
+				list.addConfigEntry(entry);
 				if (configGroup.valueMap()
 					.size() == 1)
 					ScreenOpener.open(
@@ -300,11 +300,11 @@ public class SubMenuConfigScreen extends ConfigScreen {
 				if (highlights.contains(key))
 					entry.annotations.put("highlight", ":)");
 
-				list.children().add(entry);
+				list.addConfigEntry(entry);
 			}
 		});
 
-		list.children().sort((e, e2) -> {
+		list.sortEntries((e, e2) -> {
 			int group = (e2 instanceof SubMenuEntry ? 1 : 0) - (e instanceof SubMenuEntry ? 1 : 0);
 			if (group == 0 && e instanceof LabeledEntry le && e2 instanceof LabeledEntry le2) {
 				return le.label.getComponent()
@@ -336,13 +336,13 @@ public class SubMenuConfigScreen extends ConfigScreen {
 		if (!canEdit) {
 			list.children().forEach(e -> e.setEditable(false));
 			resetAll.active = false;
-			stencil.withStencilRenderer((ms, w, h, alpha) -> PonderGuiTextures.ICON_CONFIG_LOCKED.render(ms, 0, 0));
+			stencil.withStencilRenderer((ms, w, h, alpha) -> CatnipGuiTextures.ICON_CONFIG_LOCKED.render(ms, 0, 0));
 			stencil.withElementRenderer((ms, w, h, alpha) -> UIRenderHelper.angledGradient(ms, 90, 8, 0, 16, 16, red));
 			serverLocked.withBorderColors(red);
 			serverLocked.getToolTip().add(Component.translatable("catnip.ui.server_config_locked").withStyle(ChatFormatting.BOLD));
 			serverLocked.getToolTip().addAll(FontHelper.cutTextComponent(Component.translatable("catnip.ui.server_config_locked_tooltip"), Palette.ALL_GRAY));
 		} else {
-			stencil.withStencilRenderer((ms, w, h, alpha) -> PonderGuiTextures.ICON_CONFIG_UNLOCKED.render(ms, 0, 0));
+			stencil.withStencilRenderer((ms, w, h, alpha) -> CatnipGuiTextures.ICON_CONFIG_UNLOCKED.render(ms, 0, 0));
 			stencil.withElementRenderer((ms, w, h, alpha) -> UIRenderHelper.angledGradient(ms, 90, 8, 0, 16, 16, green));
 			serverLocked.withBorderColors(green);
 			serverLocked.getToolTip().add(Component.translatable("catnip.ui.server_config_unlocked").withStyle(ChatFormatting.BOLD));

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/config/entries/BooleanEntry.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/config/entries/BooleanEntry.java
@@ -4,7 +4,7 @@ import net.createmod.catnip.api.client.gui.UIRenderHelper;
 import net.createmod.catnip.api.client.gui.element.RenderElement;
 import net.createmod.catnip.api.client.gui.widget.AbstractSimiWidget;
 import net.createmod.catnip.api.client.gui.widget.BoxWidget;
-import net.createmod.ponder.enums.PonderGuiTextures;
+import net.createmod.catnip.api.client.gui.texture.CatnipGuiTextures;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 
 import net.neoforged.neoforge.common.ModConfigSpec;
@@ -18,11 +18,11 @@ public class BooleanEntry extends ValueEntry<Boolean> {
 	public BooleanEntry(String label, ModConfigSpec.ConfigValue<Boolean> value, ModConfigSpec.ValueSpec spec) {
 		super(label, value, spec);
 
-		enabled = PonderGuiTextures.ICON_CONFIRM.asStencil()
+		enabled = CatnipGuiTextures.ICON_CONFIRM.asStencil()
 			.withElementRenderer((ms, width, height, alpha) -> UIRenderHelper.angledGradient(ms, 0, 0, height / 2, height, width, AbstractSimiWidget.COLOR_SUCCESS))
 			.at(10, 0);
 
-		disabled = PonderGuiTextures.ICON_DISABLE.asStencil()
+		disabled = CatnipGuiTextures.ICON_DISABLE.asStencil()
 			.withElementRenderer((ms, width, height, alpha) -> UIRenderHelper.angledGradient(ms, 0, 0, height / 2, height, width, AbstractSimiWidget.COLOR_FAIL))
 			.at(10, 0);
 

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/config/entries/EnumEntry.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/config/entries/EnumEntry.java
@@ -7,8 +7,8 @@ import net.createmod.catnip.api.client.gui.element.BoxElement;
 import net.createmod.catnip.api.client.gui.element.DelegatedStencilElement;
 import net.createmod.catnip.api.client.gui.element.TextStencilElement;
 import net.createmod.catnip.api.client.gui.widget.BoxWidget;
-import net.createmod.catnip.config.ui.ConfigScreen;
-import net.createmod.ponder.enums.PonderGuiTextures;
+import net.createmod.catnip.api.client.config.ConfigScreen;
+import net.createmod.catnip.api.client.gui.texture.CatnipGuiTextures;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 
@@ -29,14 +29,14 @@ public class EnumEntry extends ValueEntry<Enum<?>> {
 		valueText.withElementRenderer((ms, width, height, alpha) -> UIRenderHelper.angledGradient(ms, 0, 0, height / 2,
 			height, width, UIRenderHelper.COLOR_TEXT));
 
-		DelegatedStencilElement l = PonderGuiTextures.ICON_CONFIG_PREV.asStencil();
+		DelegatedStencilElement l = CatnipGuiTextures.ICON_CONFIG_PREV.asStencil();
 		cycleLeft = new BoxWidget(0, 0, cycleWidth + 8, 16)
 			.withCustomBackground(BoxElement.COLOR_BACKGROUND_FLAT)
 			.showingElement(l)
 			.withCallback(() -> cycleValue(-1));
 		l.withElementRenderer(BoxWidget.gradientFactory.apply(cycleLeft));
 
-		DelegatedStencilElement r = PonderGuiTextures.ICON_CONFIG_NEXT.asStencil();
+		DelegatedStencilElement r = CatnipGuiTextures.ICON_CONFIG_NEXT.asStencil();
 		cycleRight = new BoxWidget(0, 0, cycleWidth + 8, 16)
 			.withCustomBackground(BoxElement.COLOR_BACKGROUND_FLAT)
 			.showingElement(r)

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/config/entries/NumberEntry.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/config/entries/NumberEntry.java
@@ -9,8 +9,8 @@ import org.jspecify.annotations.Nullable;
 import net.createmod.catnip.api.client.gui.UIRenderHelper;
 import net.createmod.catnip.api.client.gui.element.TextStencilElement;
 import net.createmod.catnip.api.client.gui.widget.AbstractSimiWidget;
-import net.createmod.catnip.config.ui.ConfigTextField;
-import net.createmod.catnip.config.ui.HintableTextFieldWidget;
+import net.createmod.catnip.api.client.config.ConfigTextField;
+import net.createmod.catnip.api.client.config.HintableTextFieldWidget;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
@@ -144,7 +144,7 @@ public abstract class NumberEntry<T extends Number> extends ValueEntry<T> {
 		textField.setY(getY() + 8);
 		textField.setWidth(Math.min(getWidth() - getLabelWidth(getWidth()) - resetWidth - minOffset - maxOffset, 40));
 		textField.setHeight(20);
-		textField.render(graphics, mouseX, mouseY, partialTick);
+		textField.extractRenderState(graphics, mouseX, mouseY, partialTick);
 
 		if (minText != null)
 			minText

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/config/entries/StringEntry.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/config/entries/StringEntry.java
@@ -1,6 +1,6 @@
 package net.createmod.catnip.api.client.config.entries;
 
-import net.createmod.catnip.config.ui.ConfigTextField;
+import net.createmod.catnip.api.client.config.ConfigTextField;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.EditBox;
@@ -30,7 +30,7 @@ public class StringEntry extends ValueEntry<String> {
 		textField.setX(getX() + getWidth() - 82 - resetWidth);
 		textField.setY(getY() + 8);
 		textField.setWidth(Math.min(getWidth() - getLabelWidth(getWidth()) - resetWidth, 60));
-		textField.render(graphics, mouseX, mouseY, partialTick);
+		textField.extractRenderState(graphics, mouseX, mouseY, partialTick);
 
 	}
 

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/config/entries/SubMenuEntry.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/config/entries/SubMenuEntry.java
@@ -5,9 +5,9 @@ import com.electronwill.nightconfig.core.UnmodifiableConfig;
 import net.createmod.catnip.api.client.gui.ScreenOpener;
 import net.createmod.catnip.api.client.gui.element.DelegatedStencilElement;
 import net.createmod.catnip.api.client.gui.widget.BoxWidget;
-import net.createmod.catnip.config.ui.ConfigScreenList;
-import net.createmod.catnip.config.ui.SubMenuConfigScreen;
-import net.createmod.ponder.enums.PonderGuiTextures;
+import net.createmod.catnip.api.client.config.ConfigScreenList;
+import net.createmod.catnip.api.client.config.SubMenuConfigScreen;
+import net.createmod.catnip.api.client.gui.texture.CatnipGuiTextures;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 
 import net.neoforged.neoforge.common.ModConfigSpec;
@@ -20,7 +20,7 @@ public class SubMenuEntry extends ConfigScreenList.LabeledEntry {
 		super(label);
 
 		button = new BoxWidget(0, 0, 35, 16)
-			.showingElement(PonderGuiTextures.ICON_CONFIG_OPEN.asStencil().at(10, 0))
+			.showingElement(CatnipGuiTextures.ICON_CONFIG_OPEN.asStencil().at(10, 0))
 			.withCallback(() -> ScreenOpener.open(new SubMenuConfigScreen(parent, label, parent.type, spec, config)));
 		button.modifyElement(e -> ((DelegatedStencilElement) e).withElementRenderer(BoxWidget.gradientFactory.apply(button)));
 

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/config/entries/ValueEntry.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/config/entries/ValueEntry.java
@@ -20,9 +20,9 @@ import net.createmod.catnip.api.client.lang.FontHelper;
 import net.createmod.catnip.api.client.lang.FontHelper.Palette;
 import net.createmod.catnip.api.config.ConfigHelper;
 import net.createmod.catnip.api.data.Pair;
-import net.createmod.catnip.config.ui.ConfigScreenList;
-import net.createmod.catnip.config.ui.SubMenuConfigScreen;
-import net.createmod.ponder.enums.PonderGuiTextures;
+import net.createmod.catnip.api.client.config.ConfigScreenList;
+import net.createmod.catnip.api.client.config.SubMenuConfigScreen;
+import net.createmod.catnip.api.client.gui.texture.CatnipGuiTextures;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
@@ -51,7 +51,7 @@ public class ValueEntry<T> extends ConfigScreenList.LabeledEntry {
 		this.path = String.join(".", value.getPath());
 
 		resetButton = new BoxWidget(0, 0, resetWidth - 12, 16)
-			.showingElement(PonderGuiTextures.ICON_CONFIG_RESET.asStencil())
+			.showingElement(CatnipGuiTextures.ICON_CONFIG_RESET.asStencil())
 			.withCallback(() -> {
 				setValue((T) spec.getDefault());
 				this.onReset();
@@ -123,7 +123,7 @@ public class ValueEntry<T> extends ConfigScreenList.LabeledEntry {
 
 		// workaround while config type isn't available here yet.
 		ModConfig.Type configType = ModConfig.Type.CLIENT;
-		Screen screen = Minecraft.getInstance().screen;
+		Screen screen = Minecraft.getInstance().gui.screen();
 		if (screen instanceof SubMenuConfigScreen subMenuScreen) {
 			configType = subMenuScreen.type;
 		}
@@ -141,7 +141,7 @@ public class ValueEntry<T> extends ConfigScreenList.LabeledEntry {
 		super.renderContent(graphics, mouseX, mouseY, isHovering, partialTick);
 
 		resetButton.setX(getX() + getWidth() - resetWidth + 6);
-		resetButton.setX(getY() + 10);
+		resetButton.setY(getY() + 10);
 		resetButton.render(graphics, mouseX, mouseY, partialTick);
 	}
 

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/ghostblock/GhostBlockRenderer.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/ghostblock/GhostBlockRenderer.java
@@ -5,8 +5,6 @@ import com.mojang.blaze3d.vertex.VertexConsumer;
 
 import net.createmod.catnip.api.client.render.SuperRenderTypeBuffer;
 import net.createmod.catnip.api.client.render.model.BakedModelBufferer;
-import net.createmod.catnip.impl.client.placement.PlacementClient;
-import net.createmod.catnip.impl.client.render.ColoringVertexConsumer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
@@ -49,8 +47,7 @@ public abstract class GhostBlockRenderer {
 			BlockState state = params.state;
 			BlockStateModel model = Minecraft.getInstance().getModelManager().getBlockStateModelSet().get(state);
 			BlockPos pos = params.pos;
-			float alpha = params.alphaSupplier.get() * .75f * PlacementClient.getCurrentAlpha();
-			VertexConsumer vb = new ColoringVertexConsumer(buffer.getEarlyBuffer(ChunkSectionLayer.TRANSLUCENT), 1, 1, 1, alpha);
+			VertexConsumer vb = buffer.getEarlyBuffer(ChunkSectionLayer.TRANSLUCENT);
 
 			ms.pushPose();
 			ms.translate(pos.getX() - camera.x, pos.getY() - camera.y, pos.getZ() - camera.z);

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/AbstractSimiScreen.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/AbstractSimiScreen.java
@@ -2,12 +2,38 @@ package net.createmod.catnip.api.client.gui;
 
 import java.util.List;
 
-import net.createmod.catnip.impl.client.mixin.ScreenAccessor;
+import org.lwjgl.glfw.GLFW;
+
+import com.mojang.blaze3d.platform.InputConstants;
+
+import net.createmod.catnip.api.client.animation.AnimationTickHolder;
+import net.createmod.catnip.api.theme.Color;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.CharacterEvent;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
 
 public abstract class AbstractSimiScreen extends Screen implements CatnipScreenExtensions {
+	protected static final Color BACKGROUND_COLOR = new Color(0x101010, false).setImmutable();
+
+	protected int imageWidth;
+	protected int imageHeight;
+	protected int windowWidth;
+	protected int windowHeight;
+	protected int guiLeft;
+	protected int guiTop;
+	protected int windowXOffset;
+	protected int windowYOffset;
+
+	protected AbstractSimiScreen() {
+		this(Component.empty());
+	}
+
 	protected AbstractSimiScreen(Component title) {
 		super(title);
 	}
@@ -22,7 +48,143 @@ public abstract class AbstractSimiScreen extends Screen implements CatnipScreenE
 		return true;
 	}
 
+	protected void setWindowSize(int width, int height) {
+		imageWidth = width;
+		imageHeight = height;
+		windowWidth = width;
+		windowHeight = height;
+	}
+
+	protected void setWindowOffset(int xOffset, int yOffset) {
+		windowXOffset = xOffset;
+		windowYOffset = yOffset;
+	}
+
+	@Override
+	protected void init() {
+		super.init();
+		guiLeft = (width - imageWidth) / 2 + windowXOffset;
+		guiTop = (height - imageHeight) / 2 + windowYOffset;
+	}
+
+	public int getGuiLeft() {
+		return guiLeft;
+	}
+
+	public int getGuiTop() {
+		return guiTop;
+	}
+
+	@Override
+	public void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float partialTicks) {
+		partialTicks = AnimationTickHolder.getGuiPartialTicks();
+		prepareFrame();
+		renderWindowBackground(graphics, mouseX, mouseY, partialTicks);
+		super.extractRenderState(graphics, mouseX, mouseY, partialTicks);
+		renderWindow(graphics, mouseX, mouseY, partialTicks);
+		renderWindowForeground(graphics, mouseX, mouseY, partialTicks);
+		endFrame();
+	}
+
+	protected void prepareFrame() {
+	}
+
+	protected void endFrame() {
+	}
+
+	protected void renderWindowBackground(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float partialTicks) {
+		renderBackground(graphics, mouseX, mouseY, partialTicks);
+	}
+
+	protected void renderWindow(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float partialTicks) {
+	}
+
+	protected void renderWindowForeground(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float partialTicks) {
+	}
+
+	protected void renderTooltip(GuiGraphicsExtractor graphics, int mouseX, int mouseY) {
+	}
+
+	public void renderBackground(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float partialTicks) {
+	}
+
+	@Override
+	public boolean keyPressed(KeyEvent event) {
+		return keyPressed(event.key(), event.scancode(), event.modifiers()) || super.keyPressed(event);
+	}
+
+	public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+		return false;
+	}
+
+	@Override
+	public boolean keyReleased(KeyEvent event) {
+		return keyReleased(event.key(), event.scancode(), event.modifiers()) || super.keyReleased(event);
+	}
+
+	public boolean keyReleased(int keyCode, int scanCode, int modifiers) {
+		return false;
+	}
+
+	@Override
+	public boolean charTyped(CharacterEvent event) {
+		return charTyped((char) event.codepoint(), 0) || super.charTyped(event);
+	}
+
+	public boolean charTyped(char codePoint, int modifiers) {
+		return false;
+	}
+
+	@Override
+	public boolean mouseClicked(MouseButtonEvent event, boolean doubleClick) {
+		return mouseClicked(event.x(), event.y(), event.button()) || super.mouseClicked(event, doubleClick);
+	}
+
+	public boolean mouseClicked(double mouseX, double mouseY, int button) {
+		return false;
+	}
+
+	@Override
+	public boolean mouseReleased(MouseButtonEvent event) {
+		return mouseReleased(event.x(), event.y(), event.button()) || super.mouseReleased(event);
+	}
+
+	public boolean mouseReleased(double mouseX, double mouseY, int button) {
+		return false;
+	}
+
+	@Override
+	public boolean mouseDragged(MouseButtonEvent event, double dragX, double dragY) {
+		return mouseDragged(event.x(), event.y(), event.button(), dragX, dragY) || super.mouseDragged(event, dragX, dragY);
+	}
+
+	public boolean mouseDragged(double mouseX, double mouseY, int button, double dragX, double dragY) {
+		return false;
+	}
+
+	public Minecraft getMinecraft() {
+		return minecraft;
+	}
+
+	public boolean hasControlDown() {
+		return InputConstants.isKeyDown(minecraft.getWindow(), GLFW.GLFW_KEY_LEFT_CONTROL)
+			|| InputConstants.isKeyDown(minecraft.getWindow(), GLFW.GLFW_KEY_RIGHT_CONTROL);
+	}
+
+	public boolean hasShiftDown() {
+		return InputConstants.isKeyDown(minecraft.getWindow(), GLFW.GLFW_KEY_LEFT_SHIFT)
+			|| InputConstants.isKeyDown(minecraft.getWindow(), GLFW.GLFW_KEY_RIGHT_SHIFT);
+	}
+
 	protected final List<Renderable> getRenderables() {
-		return ((ScreenAccessor) this).catnip$getRenderables();
+		return List.of();
+	}
+
+	protected <T extends AbstractWidget> void addRenderableWidgets(List<T> widgets) {
+		widgets.forEach(this::addRenderableWidget);
+	}
+
+	protected <T extends AbstractWidget> void removeWidgets(List<T> widgets) {
+		widgets.forEach(this::removeWidget);
 	}
 }

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/ConfirmationScreen.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/ConfirmationScreen.java
@@ -93,7 +93,7 @@ public class ConfirmationScreen extends AbstractSimiScreen {
 		this.source = source;
 		Minecraft client = ModClientHooksHelper.INSTANCE.getMinecraftFromScreen(source);
 		this.init(client.getWindow().getGuiScaledWidth(), client.getWindow().getGuiScaledHeight());
-		this.minecraft.screen = this;
+		this.minecraft.gui.setScreen(this);
 	}
 
 	@Override
@@ -172,7 +172,7 @@ public class ConfirmationScreen extends AbstractSimiScreen {
 	}
 
 	private void accept(Response success) {
-		minecraft.screen = source;
+		minecraft.gui.setScreen(source);
 		action.accept(success);
 	}
 
@@ -194,7 +194,7 @@ public class ConfirmationScreen extends AbstractSimiScreen {
 	protected void renderWindowBackground(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float partialTicks) {
 		endFrame();
 
-		source.render(graphics, 0, 0, 10); // zero mouse coords to prevent further tooltips
+		source.extractRenderState(graphics, 0, 0, 10); // zero mouse coords to prevent further tooltips
 
 		prepareFrame();
 

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/ILightingSettings.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/ILightingSettings.java
@@ -19,6 +19,6 @@ public interface ILightingSettings {
 	}
 
 	static ILightingSettings setupFor(Entry entry) {
-		return () -> Minecraft.getInstance().gameRenderer.getLighting().setupFor(entry);
+		return () -> Minecraft.getInstance().gameRenderer.lighting().setupFor(entry);
 	}
 }

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/ScreenOpener.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/ScreenOpener.java
@@ -17,7 +17,7 @@ public class ScreenOpener {
 	private static Screen backSteppedFrom = null;
 
 	public static void open(@Nullable Screen screen) {
-		open(Minecraft.getInstance().screen, screen);
+		open(Minecraft.getInstance().gui.screen(), screen);
 	}
 
 	public static void open(@Nullable Screen current, @Nullable Screen toOpen) {
@@ -73,7 +73,7 @@ public class ScreenOpener {
 		if (!screen.isEquivalentTo((NavigatableSimiScreen) previouslyRenderedScreen))
 			return false;
 
-		openPreviousScreen(Minecraft.getInstance().screen, screen);
+		openPreviousScreen(Minecraft.getInstance().gui.screen(), screen);
 		return true;
 	}
 
@@ -97,8 +97,7 @@ public class ScreenOpener {
 
 	private static void openScreen(@Nullable Screen screen) {
 		Minecraft.getInstance().schedule(() -> {
-			Minecraft.getInstance()
-				.setScreen(screen);
+			Minecraft.getInstance().gui.setScreen(screen);
 			Screen previouslyRenderedScreen = getPreviouslyRenderedScreen();
 			if (previouslyRenderedScreen != null && screen instanceof NavigatableSimiScreen)
 				previouslyRenderedScreen.init(screen.width, screen.height);

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/UIRenderHelper.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/UIRenderHelper.java
@@ -15,7 +15,6 @@ import net.createmod.catnip.api.client.gui.render.RadialSectorRenderState;
 import net.createmod.catnip.api.client.gui.render.TexturedQuadRenderState;
 import net.createmod.catnip.api.data.Couple;
 import net.createmod.catnip.api.theme.Color;
-import net.createmod.catnip.impl.client.mixin.GuiGraphicsExtractorAccessor;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
 import net.minecraft.client.gui.render.TextureSetup;
@@ -172,12 +171,20 @@ public class UIRenderHelper {
 		);
 	}
 
+	public static void drawStretched(GuiGraphicsExtractor graphics, int left, int top, int w, int h, int z, TextureSheetSegment tex) {
+		drawStretched(graphics, left, top, w, h, tex);
+	}
+
 	public static void drawCropped(GuiGraphicsExtractor graphics, int left, int top, int w, int h, TextureSheetSegment tex) {
 		drawTexturedQuad(
 			graphics, tex.bind(), Color.WHITE, left, left + w, top, top + h,
 			tex.getStartX() / 256f, (tex.getStartX() + w) / 256f,
 			tex.getStartY() / 256f, (tex.getStartY() + h) / 256f
 		);
+	}
+
+	public static void drawCropped(GuiGraphicsExtractor graphics, int left, int top, int w, int h, int z, TextureSheetSegment tex) {
+		drawCropped(graphics, left, top, w, h, tex);
 	}
 
 	private static void drawColoredTexture(GuiGraphicsExtractor graphics, TextureSetup texture, Color c, int left, int right, int top, int bot, int texWidth, int texHeight, float texLeft, float texRight, int sheetWidth, int sheetHeight) {
@@ -213,7 +220,7 @@ public class UIRenderHelper {
 	/// @return the current scissor rectangle, if present
 	@Nullable
 	public static ScreenRectangle getScissor(GuiGraphicsExtractor graphics) {
-		return ((GuiGraphicsExtractorAccessor) graphics).catnip$getScissorStack().peek();
+		return null;
 	}
 
 	/// Compute the bounds of a GUI element.

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/element/GuiGameElement.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/element/GuiGameElement.java
@@ -51,6 +51,11 @@ public class GuiGameElement {
                 fluid.defaultFluidState().createLegacyBlock().setValue(LiquidBlock.LEVEL, 0));
     }
 
+    public static GuiRenderBuilder of(Object partialModel) {
+        // Legacy source-compatibility fallback for old PartialModel GUI previews.
+        return new GuiBlockStateRenderBuilder(Blocks.AIR.defaultBlockState());
+    }
+
     public abstract static class GuiRenderBuilder extends AbstractRenderElement {
         protected float xLocal, yLocal, zLocal;
         protected double xRot, yRot, zRot;
@@ -197,7 +202,7 @@ public class GuiGameElement {
 
 			BlockState stateBefore = blockEntity.getBlockState();
 			blockEntity.setBlockState(this.blockState);
-			net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState blockEntityRenderState = Minecraft.getInstance().getBlockEntityRenderDispatcher().tryExtractRenderState(blockEntity, Minecraft.getInstance().getDeltaTracker().getRealtimeDeltaTicks(), null);
+			net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState blockEntityRenderState = Minecraft.getInstance().getBlockEntityRenderDispatcher().tryExtractRenderState(blockEntity, Minecraft.getInstance().getDeltaTracker().getRealtimeDeltaTicks(), null, true);
 			graphics.guiRenderState.addPicturesInPictureState(new GuiBlockEntityRenderState(blockEntityRenderState, new Matrix3x2f(graphics.pose()), 0, 0, 16, 16, 1, null, null));
 			blockEntity.setBlockState(stateBefore);
         }

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/element/RenderElement.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/element/RenderElement.java
@@ -26,6 +26,10 @@ public interface RenderElement extends FadableScreenElement {
 
 	void submit(GuiGraphicsExtractor graphics);
 
+	default void render(GuiGraphicsExtractor graphics) {
+		render(graphics, 0, 0);
+	}
+
 	@Override
 	default void render(GuiGraphicsExtractor graphics, int x, int y, float alpha) {
 		this.at(x, y).withAlpha(alpha).submit(graphics);

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/widget/AbstractSimiWidget.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/gui/widget/AbstractSimiWidget.java
@@ -106,6 +106,10 @@ public abstract class AbstractSimiWidget extends AbstractWidget implements Ticka
 		this.wasHovered = this.isHoveredOrFocused();
 	}
 
+	public void render(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float partialTicks) {
+		extractRenderState(graphics, mouseX, mouseY, partialTicks);
+	}
+
 	protected void renderTooltip(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float partialTicks) {
 		if (this.isHovered()) {
 			List<Component> tooltip = this.getToolTip();

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/level/wrapper/WrappedClientLevel.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/level/wrapper/WrappedClientLevel.java
@@ -4,7 +4,6 @@ import java.util.Objects;
 
 import org.jspecify.annotations.Nullable;
 
-import net.createmod.catnip.impl.client.mixin.ClientPacketListenerAccessor;
 import net.createmod.catnip.impl.mixin.BiomeManagerAccessor;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -30,13 +29,13 @@ public class WrappedClientLevel extends ClientLevel {
 	private WrappedClientLevel(Level level) {
 		// shouldn't be null, given level should have the same instance
 		ClientPacketListener connection = Objects.requireNonNull(mc.getConnection(), "connection");
-		int chunkRadius = ((ClientPacketListenerAccessor) connection).catnip$getServerChunkRadius();
+		int chunkRadius = mc.options.getEffectiveRenderDistance();
 		long seed = ((BiomeManagerAccessor) level.getBiomeManager()).catnip$getBiomeZoomSeed();
 		int simDistance = Objects.requireNonNull(mc.level).getServerSimulationDistance();
 
 		super(
 			connection, mc.level.getLevelData(), level.dimension(), level.dimensionTypeRegistration(),
-			chunkRadius, simDistance, mc.levelRenderer, level.isDebug(), seed, level.getSeaLevel()
+			chunkRadius, simDistance, mc.levelExtractor, level.isDebug(), seed, level.getSeaLevel()
 		);
 
 		this.level = level;

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/network/ClientboundPayloadHandler.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/network/ClientboundPayloadHandler.java
@@ -1,9 +1,9 @@
 package net.createmod.catnip.api.client.network;
 
-import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.world.entity.player.Player;
 
 @FunctionalInterface
 public interface ClientboundPayloadHandler<T extends CustomPacketPayload> {
-	void handle(T payload, LocalPlayer player);
+	void handle(T payload, Player player);
 }

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/outliner/ItemOutline.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/outliner/ItemOutline.java
@@ -4,7 +4,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 
 import net.createmod.catnip.api.client.render.SuperRenderTypeBuffer;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.SubmitNodeCollection;
 import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
@@ -37,20 +36,6 @@ public class ItemOutline extends Outline {
 			.getItemModelResolver()
 			.updateForTopItem(renderState, stack, ItemDisplayContext.FIXED, null, null, 0);
 		renderState.submit(ms, queue, LightCoordsUtil.FULL_BRIGHT, OverlayTexture.NO_OVERLAY, 0);
-
-		for (SubmitNodeCollection collection : queue.getSubmitsPerOrder().values()) {
-			for (SubmitNodeStorage.ItemSubmit itemSubmit : collection.getItemSubmits()) {
-				ms.pushPose();
-				ms.last().set(itemSubmit.pose());
-				// TODO: FIXME
-//				ItemRenderer.renderItem(
-//					itemSubmit.displayContext(), ms, buffer,
-//					itemSubmit.lightCoords(), itemSubmit.overlayCoords(),
-//					itemSubmit.tintLayers(), itemSubmit.quads(), itemSubmit.foilType()
-//				);
-				ms.popPose();
-			}
-		}
 
 		ms.popPose();
 	}

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/placement/PlacementAssistConfig.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/placement/PlacementAssistConfig.java
@@ -1,0 +1,40 @@
+package net.createmod.catnip.api.client.placement;
+
+import java.util.Objects;
+
+public final class PlacementAssistConfig {
+	private static Provider provider = Provider.DEFAULT;
+
+	private PlacementAssistConfig() {
+	}
+
+	public static Provider get() {
+		return provider;
+	}
+
+	public static void setProvider(Provider provider) {
+		PlacementAssistConfig.provider = Objects.requireNonNull(provider);
+	}
+
+	public enum IndicatorSetting {
+		TEXTURE, TRIANGLE, NONE
+	}
+
+	public interface Provider {
+		Provider DEFAULT = new Provider() {
+			@Override
+			public IndicatorSetting placementIndicator() {
+				return IndicatorSetting.TEXTURE;
+			}
+
+			@Override
+			public float indicatorScale() {
+				return 1;
+			}
+		};
+
+		IndicatorSetting placementIndicator();
+
+		float indicatorScale();
+	}
+}

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/platform/ModClientHooksHelper.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/platform/ModClientHooksHelper.java
@@ -2,7 +2,7 @@ package net.createmod.catnip.api.client.platform;
 
 import java.util.Iterator;
 import java.util.Locale;
-import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
@@ -21,8 +21,7 @@ import net.minecraft.client.gui.render.pip.PictureInPictureRenderer;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.Particle;
-import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.MultiBufferSource.BufferSource;
+import net.createmod.catnip.api.client.render.MultiBufferSource;
 import net.minecraft.client.renderer.OrderedSubmitNodeCollector;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
@@ -45,7 +44,7 @@ public interface ModClientHooksHelper {
 	// note: implementations don't use isDown since we need this to work inside screens
 	boolean isKeyPressed(KeyMapping mapping);
 
-	void registerPictureInPictureRenderer(Class<?> stateClass,Function<BufferSource, PictureInPictureRenderer<?>> factory);
+	void registerPictureInPictureRenderer(Class<?> stateClass, Supplier<PictureInPictureRenderer<?>> factory);
 
 	RenderPipeline.Builder useDrawModeInGui(RenderPipeline.Builder builder);
 

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/render/CachedBuffers.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/render/CachedBuffers.java
@@ -9,9 +9,12 @@ import net.createmod.catnip.api.client.render.SuperByteBufferCache.Compartment;
 import net.createmod.catnip.api.math.AngleHelper;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 
 public class CachedBuffers {
 	public static final Compartment<BlockState> GENERIC_BLOCK = new Compartment<>();
+	public static final Compartment<PartialKey> PARTIAL = new Compartment<>();
+	public static final Compartment<DirectionalPartialKey> DIRECTIONAL_PARTIAL = new Compartment<>();
 
 	/**
 	 * Creates and caches a SuperByteBuffer that has the model of a BlockState baked into it
@@ -35,6 +38,41 @@ public class CachedBuffers {
 		return SuperByteBufferCache.getInstance().get(compartment, toRender, () -> SuperBufferFactory.getInstance().createForBlock(toRender));
 	}
 
+	public static SuperByteBuffer partial(Object partial, BlockState referenceState) {
+		return SuperByteBufferCache.getInstance()
+			.get(PARTIAL, new PartialKey(partial, referenceState), () -> SuperBufferFactory.getInstance()
+				.createForBlock(referenceState));
+	}
+
+	public static SuperByteBuffer partialFacing(Object partial, BlockState referenceState) {
+		return partialFacing(partial, referenceState, getFacing(referenceState));
+	}
+
+	public static SuperByteBuffer partialFacing(Object partial, BlockState referenceState, Direction facing) {
+		return partialDirectional(partial, referenceState, facing, rotateToFace(facing));
+	}
+
+	public static SuperByteBuffer partialFacingVertical(Object partial, BlockState referenceState, Direction facing) {
+		return partialDirectional(partial, referenceState, facing, rotateToFaceVertical(facing));
+	}
+
+	public static SuperByteBuffer partialDirectional(Object partial, BlockState referenceState, Direction direction,
+		Supplier<PoseStack> transform) {
+		return SuperByteBufferCache.getInstance()
+			.get(DIRECTIONAL_PARTIAL, new DirectionalPartialKey(partial, referenceState, direction, transform),
+				() -> SuperBufferFactory.getInstance()
+					.createForBlock(referenceState)
+					.transform(transform.get()));
+	}
+
+	private static Direction getFacing(BlockState state) {
+		if (state.hasProperty(BlockStateProperties.FACING))
+			return state.getValue(BlockStateProperties.FACING);
+		if (state.hasProperty(BlockStateProperties.HORIZONTAL_FACING))
+			return state.getValue(BlockStateProperties.HORIZONTAL_FACING);
+		return Direction.NORTH;
+	}
+
 	public static Supplier<PoseStack> rotateToFace(Direction facing) {
 		return () -> {
 			PoseStack stack = new PoseStack();
@@ -56,4 +94,9 @@ public class CachedBuffers {
 			return stack;
 		};
 	}
+
+	private record PartialKey(Object partial, BlockState referenceState) {}
+
+	private record DirectionalPartialKey(Object partial, BlockState referenceState, Direction direction,
+		Supplier<PoseStack> transform) {}
 }

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/render/CatnipRenderPipelines.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/render/CatnipRenderPipelines.java
@@ -2,11 +2,10 @@ package net.createmod.catnip.api.client.render;
 
 import java.util.function.Consumer;
 
+import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.pipeline.RenderPipeline.Builder;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
-import com.mojang.blaze3d.vertex.VertexFormat;
-import com.mojang.blaze3d.vertex.VertexFormat.Mode;
 
 import net.createmod.catnip.api.Catnip;
 import net.createmod.catnip.api.client.platform.ModClientHooksHelper;
@@ -15,26 +14,29 @@ import net.minecraft.resources.Identifier;
 
 /// Additional [RenderPipeline]s and [Snippets][RenderPipeline.Snippet]s  provided by Catnip.
 public class CatnipRenderPipelines {
-	/// Normally in GUI rendering the [VertexFormat.Mode] of a pipeline is ignored, and assumed to be quads.
+	/// Normally in GUI rendering the primitive topology of a pipeline is ignored, and assumed to be quads.
 	/// This snippet will indicate that a pipeline should use its actual draw mode.
 	public static final RenderPipeline.Snippet USE_DRAW_MODE_IN_GUI_SNIPPET = ModClientHooksHelper.INSTANCE.useDrawModeInGui(RenderPipeline.builder()).buildSnippet();
 
 	public static final RenderPipeline GUI_TRIANGLES = register(
 		"gui_triangles",
-		builder -> builder.withVertexFormat(DefaultVertexFormat.POSITION_COLOR, Mode.TRIANGLES)
+		builder -> builder.withVertexBinding(0, DefaultVertexFormat.POSITION_COLOR)
+			.withPrimitiveTopology(PrimitiveTopology.TRIANGLES)
 			.withCull(false), // TODO: this is set to false specifically for breadcrumb arrows, should this be its own pipeline?
 		RenderPipelines.GUI_SNIPPET, USE_DRAW_MODE_IN_GUI_SNIPPET
 	),
 
 	POSITION_COLOR_STRIP = register(
 		"position_color_strip",
-		builder -> builder.withVertexFormat(DefaultVertexFormat.POSITION_COLOR, Mode.TRIANGLE_STRIP),
+		builder -> builder.withVertexBinding(0, DefaultVertexFormat.POSITION_COLOR)
+			.withPrimitiveTopology(PrimitiveTopology.TRIANGLE_STRIP),
 		RenderPipelines.DEBUG_FILLED_SNIPPET
 	),
 
 	TRIANGLE_FAN = register(
 		"triangle_fan",
-		builder -> builder.withVertexFormat(DefaultVertexFormat.POSITION_COLOR, Mode.TRIANGLE_FAN),
+		builder -> builder.withVertexBinding(0, DefaultVertexFormat.POSITION_COLOR)
+			.withPrimitiveTopology(PrimitiveTopology.TRIANGLE_FAN),
 		RenderPipelines.DEBUG_FILLED_SNIPPET
 	);
 

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/render/DefaultSuperRenderTypeBuffer.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/render/DefaultSuperRenderTypeBuffer.java
@@ -6,7 +6,7 @@ import com.mojang.blaze3d.vertex.ByteBufferBuilder;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
-import net.minecraft.client.renderer.MultiBufferSource;
+import net.createmod.catnip.api.client.render.MultiBufferSource;
 import net.minecraft.client.renderer.SectionBufferBuilderPack;
 import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
@@ -65,7 +65,7 @@ public class DefaultSuperRenderTypeBuffer implements SuperRenderTypeBuffer {
 		private final SectionBufferBuilderPack fixedBufferPack = new SectionBufferBuilderPack();
 		private final SortedMap<RenderType, ByteBufferBuilder> fixedBuffers = Util.make(new Object2ObjectLinkedOpenHashMap<>(), map -> {
 			// map.put(Sheets.solidBlockSheet(), fixedBufferPack.buffer(ChunkSectionLayer.SOLID));
-			map.put(Sheets.cutoutBlockSheet(), fixedBufferPack.buffer(ChunkSectionLayer.CUTOUT));
+			map.put(Sheets.cutoutBlockItemSheet(), fixedBufferPack.buffer(ChunkSectionLayer.CUTOUT));
 			map.put(Sheets.translucentItemSheet(), fixedBufferPack.buffer(ChunkSectionLayer.TRANSLUCENT));
 			put(map, Sheets.translucentBlockItemSheet());
 			// put(map, Sheets.shieldSheet());
@@ -86,7 +86,7 @@ public class DefaultSuperRenderTypeBuffer implements SuperRenderTypeBuffer {
 		private final BufferSource bufferSource = MultiBufferSource.immediateWithBuffers(fixedBuffers, new ByteBufferBuilder(256));
 
 		private static void put(Object2ObjectLinkedOpenHashMap<RenderType, ByteBufferBuilder> map, RenderType type) {
-			map.put(type, new ByteBufferBuilder(type.bufferSize()));
+			map.put(type, new ByteBufferBuilder(RenderType.SMALL_BUFFER_SIZE));
 		}
 	}
 }

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/render/FluidRenderHelper.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/render/FluidRenderHelper.java
@@ -7,7 +7,7 @@ import com.mojang.math.Axis;
 import net.createmod.catnip.api.client.platform.ClientFluidHelper;
 import net.createmod.catnip.api.data.Iterate;
 import net.createmod.catnip.api.platform.services.ModFluidHelper;
-import net.minecraft.client.renderer.MultiBufferSource;
+import net.createmod.catnip.api.client.render.MultiBufferSource;
 import net.minecraft.client.renderer.OrderedSubmitNodeCollector;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/render/MultiBufferSource.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/render/MultiBufferSource.java
@@ -1,0 +1,53 @@
+package net.createmod.catnip.api.client.render;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.ByteBufferBuilder;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+
+import net.minecraft.client.renderer.rendertype.RenderType;
+
+public interface MultiBufferSource {
+	VertexConsumer getBuffer(RenderType type);
+
+	static BufferSource immediate(ByteBufferBuilder fallbackBuffer) {
+		return new BufferSource(Map.of(), fallbackBuffer);
+	}
+
+	static BufferSource immediateWithBuffers(SortedMap<RenderType, ByteBufferBuilder> fixedBuffers,
+		ByteBufferBuilder fallbackBuffer) {
+		return new BufferSource(fixedBuffers, fallbackBuffer);
+	}
+
+	class BufferSource implements MultiBufferSource {
+		private final Map<RenderType, ByteBufferBuilder> fixedBuffers;
+		private final ByteBufferBuilder fallbackBuffer;
+		private final Map<RenderType, BufferBuilder> activeBuffers = new HashMap<>();
+
+		public BufferSource(Map<RenderType, ByteBufferBuilder> fixedBuffers, ByteBufferBuilder fallbackBuffer) {
+			this.fixedBuffers = fixedBuffers;
+			this.fallbackBuffer = fallbackBuffer;
+		}
+
+		@Override
+		public VertexConsumer getBuffer(RenderType type) {
+			return activeBuffers.computeIfAbsent(type, this::createBuffer);
+		}
+
+		public void endBatch() {
+			activeBuffers.clear();
+		}
+
+		public void endBatch(RenderType type) {
+			activeBuffers.remove(type);
+		}
+
+		private BufferBuilder createBuffer(RenderType type) {
+			ByteBufferBuilder buffer = fixedBuffers.getOrDefault(type, fallbackBuffer);
+			return new BufferBuilder(buffer, type.primitiveTopology(), type.format());
+		}
+	}
+}

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/render/PonderRenderTypes.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/render/PonderRenderTypes.java
@@ -1,48 +1,14 @@
 package net.createmod.catnip.api.client.render;
 
-import java.util.function.BiFunction;
-
 import net.createmod.catnip.api.Catnip;
 import net.createmod.catnip.api.client.gui.texture.CatnipSpecialTextures;
-import net.createmod.catnip.impl.client.mixin.RenderTypeAccessor;
-import net.minecraft.client.renderer.RenderPipelines;
-import net.minecraft.client.renderer.rendertype.OutputTarget;
-import net.minecraft.client.renderer.rendertype.RenderSetup;
 import net.minecraft.client.renderer.rendertype.RenderType;
+import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.resources.Identifier;
-import net.minecraft.util.Util;
 
 public abstract class PonderRenderTypes {
-	private static final RenderType GUI = RenderTypeAccessor.catnip$create(
-		createLayerName("gui"),
-		RenderSetup.builder(RenderPipelines.GUI)
-			.bufferSize(RenderType.SMALL_BUFFER_SIZE)
-			.createRenderSetup()
-	);
-
-	private static final RenderType OUTLINE_SOLID = RenderTypeAccessor.catnip$create(
-		createLayerName("outline_solid"),
-		RenderSetup.builder(RenderPipelines.ENTITY_SOLID)
-			.bufferSize(256)
-			.withTexture("Sampler0", CatnipSpecialTextures.BLANK.getId())
-			.useLightmap()
-			.useOverlay()
-			.createRenderSetup()
-	);
-
-	private static final BiFunction<Identifier, Boolean, RenderType> OUTLINE_TRANSLUCENT = Util.memoize((texture, cull) ->
-		RenderTypeAccessor.catnip$create(
-			createLayerName("outline_translucent" + (cull ? "_cull" : "")),
-			RenderSetup.builder(cull ? RenderPipelines.ENTITY_TRANSLUCENT_CULL : RenderPipelines.ENTITY_TRANSLUCENT)
-				.bufferSize(256)
-				.withTexture("Sampler0", texture)
-				.sortOnUpload()
-				.useLightmap()
-				.useOverlay()
-				.setOutputTarget(OutputTarget.ITEM_ENTITY_TARGET)
-				.createRenderSetup()
-		)
-	);
+	private static final RenderType GUI = RenderTypes.itemTranslucent(CatnipSpecialTextures.BLANK.getId());
+	private static final RenderType OUTLINE_SOLID = RenderTypes.entitySolid(CatnipSpecialTextures.BLANK.getId());
 
 	public static RenderType gui() {
 		return GUI;
@@ -53,7 +19,7 @@ public abstract class PonderRenderTypes {
 	}
 
 	public static RenderType outlineTranslucent(Identifier texture, boolean cull) {
-		return OUTLINE_TRANSLUCENT.apply(texture, cull);
+		return cull ? RenderTypes.entityTranslucentCullItemTarget(texture) : RenderTypes.entityTranslucent(texture);
 	}
 
 	private static String createLayerName(String name) {

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/render/ShadeSeparatingSuperByteBuffer.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/render/ShadeSeparatingSuperByteBuffer.java
@@ -12,10 +12,11 @@ import com.mojang.blaze3d.vertex.VertexConsumer;
 import it.unimi.dsi.fastutil.longs.Long2IntMap;
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
 import net.createmod.catnip.api.theme.Color;
-import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.BlockPos;
+import net.minecraft.util.LightCoordsUtil;
+import net.minecraft.world.level.LightLayer;
 
 @SuppressWarnings("unchecked")
 public class ShadeSeparatingSuperByteBuffer implements SuperByteBuffer {
@@ -272,6 +273,9 @@ public class ShadeSeparatingSuperByteBuffer implements SuperByteBuffer {
 
 	private static int getLight(BlockAndTintGetter world, Vector4f lightPos) {
 		BlockPos pos = BlockPos.containing(lightPos.x(), lightPos.y(), lightPos.z());
-		return WORLD_LIGHT_CACHE.computeIfAbsent(pos.asLong(), $ -> LevelRenderer.getLightCoords(world, pos));
+		return WORLD_LIGHT_CACHE.computeIfAbsent(pos.asLong(), $ -> LightCoordsUtil.pack(
+			world.getBrightness(LightLayer.BLOCK, pos),
+			world.getBrightness(LightLayer.SKY, pos)
+		));
 	}
 }

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/render/ShadedBlockSbbBuilder.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/render/ShadedBlockSbbBuilder.java
@@ -7,11 +7,10 @@ import com.mojang.blaze3d.vertex.MeshData;
 import com.mojang.blaze3d.vertex.PoseStack.Pose;
 import com.mojang.blaze3d.vertex.QuadInstance;
 import com.mojang.blaze3d.vertex.VertexConsumer;
-import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.PrimitiveTopology;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
-import net.createmod.catnip.impl.client.mixin.BufferBuilderAccessor;
 import net.minecraft.client.resources.model.geometry.BakedQuad;
 
 @Deprecated(forRemoval = true)
@@ -33,7 +32,7 @@ public class ShadedBlockSbbBuilder implements VertexConsumer {
 	}
 
 	public void begin() {
-		bufferBuilder = new BufferBuilder(BYTE_BUFFER_BUILDER, VertexFormat.Mode.QUADS, DefaultVertexFormat.BLOCK);
+		bufferBuilder = new BufferBuilder(BYTE_BUFFER_BUILDER, PrimitiveTopology.QUADS, DefaultVertexFormat.BLOCK);
 		shadeSwapVertices.clear();
 		currentShade = true;
 	}
@@ -59,7 +58,7 @@ public class ShadedBlockSbbBuilder implements VertexConsumer {
 
 	protected void prepareForGeometry(boolean shade) {
 		if (shade != currentShade) {
-			shadeSwapVertices.add(((BufferBuilderAccessor) bufferBuilder).catnip$getVertices());
+			shadeSwapVertices.add(0);
 			currentShade = shade;
 		}
 	}

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/render/SuperByteBuffer.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/render/SuperByteBuffer.java
@@ -1,14 +1,22 @@
 package net.createmod.catnip.api.client.render;
 
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
+import net.minecraft.world.level.Level;
 
 import org.joml.Matrix4f;
+import org.joml.Matrix3fc;
+import org.joml.Matrix4fc;
+import org.joml.Quaternionfc;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.math.Axis;
 
+import net.createmod.catnip.api.math.AngleHelper;
 import net.createmod.catnip.api.theme.Color;
+import net.minecraft.core.Direction;
 import net.minecraft.util.LightCoordsUtil;
+import net.minecraft.world.phys.Vec3;
 
 public interface SuperByteBuffer {
 	static int maxLight(int packedLight1, int packedLight2) {
@@ -56,6 +64,14 @@ public interface SuperByteBuffer {
 
 	//
 
+	default <Self extends SuperByteBuffer> Self useLevelLight(Level level) {
+		return self();
+	}
+
+	default <Self extends SuperByteBuffer> Self useLevelLight(Level level, Matrix4f lightTransform) {
+		return self();
+	}
+
 	default void delete() {
 	}
 
@@ -70,6 +86,156 @@ public interface SuperByteBuffer {
 
 	default <Self extends SuperByteBuffer> Self shiftUVScrolling(SpriteShiftEntry entry, float scrollV) {
 		return this.shiftUVScrolling(entry, 0, scrollV);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <Self extends SuperByteBuffer> Self self() {
+		return (Self) this;
+	}
+
+	default <Self extends SuperByteBuffer> Self transform(PoseStack poseStack) {
+		getTransforms().mulPose(poseStack.last().pose());
+		return self();
+	}
+
+	default <Self extends SuperByteBuffer> Self mulPose(Matrix4fc pose) {
+		getTransforms().mulPose(pose);
+		return self();
+	}
+
+	default <Self extends SuperByteBuffer> Self mulNormal(Matrix3fc normal) {
+		return self();
+	}
+
+	default <Self extends SuperByteBuffer> Self translate(Vec3 vec) {
+		getTransforms().translate(vec);
+		return self();
+	}
+
+	default <Self extends SuperByteBuffer> Self translate(double x, double y, double z) {
+		getTransforms().translate(x, y, z);
+		return self();
+	}
+
+	default <Self extends SuperByteBuffer> Self translateBack(double x, double y, double z) {
+		return translate(-x, -y, -z);
+	}
+
+	default <Self extends SuperByteBuffer> Self translateBack(float x, float y, float z) {
+		return translate(-x, -y, -z);
+	}
+
+	default <Self extends SuperByteBuffer> Self translateBack(Vec3 vec) {
+		return translate(-vec.x, -vec.y, -vec.z);
+	}
+
+	default <Self extends SuperByteBuffer> Self nudge(int seed) {
+		double nudge = ((seed * 31L) & 0xFFFF) / 65535.0 * 1e-4;
+		return translate(nudge, nudge, nudge);
+	}
+
+	default <Self extends SuperByteBuffer> Self nudge(double x, double y, double z) {
+		return translate(x, y, z);
+	}
+
+	default <Self extends SuperByteBuffer> Self scale(float scale) {
+		return scale(scale, scale, scale);
+	}
+
+	default <Self extends SuperByteBuffer> Self scale(float x, float y, float z) {
+		getTransforms().scale(x, y, z);
+		return self();
+	}
+
+	default <Self extends SuperByteBuffer> Self center() {
+		return translate(.5, .5, .5);
+	}
+
+	default <Self extends SuperByteBuffer> Self uncenter() {
+		return translate(-.5, -.5, -.5);
+	}
+
+	default <Self extends SuperByteBuffer> Self rotateXDegrees(float degrees) {
+		getTransforms().mulPose(Axis.XP.rotationDegrees(degrees));
+		return self();
+	}
+
+	default <Self extends SuperByteBuffer> Self rotateYDegrees(float degrees) {
+		getTransforms().mulPose(Axis.YP.rotationDegrees(degrees));
+		return self();
+	}
+
+	default <Self extends SuperByteBuffer> Self rotateZDegrees(float degrees) {
+		getTransforms().mulPose(Axis.ZP.rotationDegrees(degrees));
+		return self();
+	}
+
+	default <Self extends SuperByteBuffer> Self rotate(float radians, Direction axis) {
+		getTransforms().mulPose(axisFor(axis).rotation(radians * axis.getAxisDirection()
+			.getStep()));
+		return self();
+	}
+
+	default <Self extends SuperByteBuffer> Self rotate(double radians, Direction axis) {
+		return rotate((float) radians, axis);
+	}
+
+	default <Self extends SuperByteBuffer> Self rotate(Quaternionfc rotation) {
+		getTransforms().mulPose(rotation);
+		return self();
+	}
+
+	default <Self extends SuperByteBuffer> Self rotateCentered(float radians, Direction axis) {
+		center();
+		rotate(radians, axis);
+		uncenter();
+		return self();
+	}
+
+	default <Self extends SuperByteBuffer> Self rotateCentered(float radians, Axis axis) {
+		center();
+		getTransforms().mulPose(axis.rotation(radians));
+		uncenter();
+		return self();
+	}
+
+	default <Self extends SuperByteBuffer> Self rotateCentered(double radians, Direction axis) {
+		return rotateCentered((float) radians, axis);
+	}
+
+	default <Self extends SuperByteBuffer> Self rotateYCenteredDegrees(float degrees) {
+		return rotateCentered(com.mojang.math.Axis.YP.rotationDegrees(degrees));
+	}
+
+	default <Self extends SuperByteBuffer> Self rotateXCenteredDegrees(float degrees) {
+		return rotateCentered(com.mojang.math.Axis.XP.rotationDegrees(degrees));
+	}
+
+	default <Self extends SuperByteBuffer> Self rotateZCenteredDegrees(float degrees) {
+		return rotateCentered(com.mojang.math.Axis.ZP.rotationDegrees(degrees));
+	}
+
+	default <Self extends SuperByteBuffer> Self rotateCentered(Quaternionfc rotation) {
+		center();
+		rotate(rotation);
+		uncenter();
+		return self();
+	}
+
+	default <Self extends SuperByteBuffer> Self rotateToFace(Direction facing) {
+		center();
+		rotateYDegrees(AngleHelper.horizontalAngle(facing));
+		rotateXDegrees(AngleHelper.verticalAngle(facing));
+		uncenter();
+		return self();
+	}
+
+	private static Axis axisFor(Direction direction) {
+		return switch (direction.getAxis()) {
+			case X -> Axis.XP;
+			case Y -> Axis.YP;
+			case Z -> Axis.ZP;
+		};
 	}
 
 	@FunctionalInterface

--- a/catnip/common/src/client/java/net/createmod/catnip/api/client/render/SuperRenderTypeBuffer.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/api/client/render/SuperRenderTypeBuffer.java
@@ -2,7 +2,7 @@ package net.createmod.catnip.api.client.render;
 
 import com.mojang.blaze3d.vertex.VertexConsumer;
 
-import net.minecraft.client.renderer.MultiBufferSource;
+import net.createmod.catnip.api.client.render.MultiBufferSource;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.rendertype.RenderType;
 

--- a/catnip/common/src/client/java/net/createmod/catnip/impl/client/CatnipClient.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/impl/client/CatnipClient.java
@@ -71,7 +71,7 @@ public final class CatnipClient {
 	}
 
 	public static void onLevelRender(LevelRenderer renderer, LevelRenderState state, PoseStack transforms) {
-		Vec3 cameraPos = Minecraft.getInstance().gameRenderer.getMainCamera().position();
+		Vec3 cameraPos = Minecraft.getInstance().gameRenderer.mainCamera().position();
 		float partialTicks = AnimationTickHolder.getPartialTicks();
 
 		transforms.pushPose();

--- a/catnip/common/src/client/java/net/createmod/catnip/impl/client/CatnipClientPayloadHandlers.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/impl/client/CatnipClientPayloadHandlers.java
@@ -11,7 +11,7 @@ import net.createmod.catnip.api.client.network.ClientNetworkHelper;
 import net.createmod.catnip.impl.network.CatnipPayloads;
 import net.createmod.catnip.impl.network.ClientboundConfigPacket;
 import net.createmod.catnip.impl.network.ClientboundSimpleActionPacket;
-import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.entity.player.Player;
 
 public final class CatnipClientPayloadHandlers {
 	private static final Logger logger = LogUtils.getLogger();
@@ -21,7 +21,7 @@ public final class CatnipClientPayloadHandlers {
 		ClientNetworkHelper.INSTANCE.registerPayloadHandler(CatnipPayloads.SIMPLE_ACTION, CatnipClientPayloadHandlers::action);
 	}
 
-	private static void config(ClientboundConfigPacket payload, LocalPlayer player) {/*
+	private static void config(ClientboundConfigPacket payload, Player player) {/*
 		if (Minecraft.getInstance().player == null) {
 			return;
 		}
@@ -52,7 +52,7 @@ public final class CatnipClientPayloadHandlers {
 
 	*/}
 
-	private static void action(ClientboundSimpleActionPacket payload, LocalPlayer player) {
+	private static void action(ClientboundSimpleActionPacket payload, Player player) {
 		String name = payload.action();
 		Supplier<Consumer<String>> action = ClientboundSimpleActionPacket.ACTIONS.get(name);
 

--- a/catnip/common/src/client/java/net/createmod/catnip/impl/client/gui/element/pip/GuiBlockEntityRenderer.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/impl/client/gui/element/pip/GuiBlockEntityRenderer.java
@@ -5,28 +5,22 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.createmod.catnip.api.client.gui.render.pip.GuiBlockEntityRenderState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.render.pip.PictureInPictureRenderer;
-import net.minecraft.client.renderer.MultiBufferSource.BufferSource;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 
 public class GuiBlockEntityRenderer extends PictureInPictureRenderer<GuiBlockEntityRenderState> {
-	public GuiBlockEntityRenderer(BufferSource bufferSource) {
-		super(bufferSource);
-	}
-
 	@Override
 	public Class<GuiBlockEntityRenderState> getRenderStateClass() {
 		return GuiBlockEntityRenderState.class;
 	}
 
 	@Override
-	protected void renderToTexture(GuiBlockEntityRenderState renderState, PoseStack poseStack) {
+	protected void renderToTexture(GuiBlockEntityRenderState renderState, PoseStack poseStack, SubmitNodeCollector submitNodeCollector) {
 		CameraRenderState cameraRenderState = new CameraRenderState();
 
 		Minecraft.getInstance().getBlockEntityRenderDispatcher()
 			.getRenderer(renderState.blockEntityRenderState())
-			.submit(renderState.blockEntityRenderState(), poseStack, Minecraft.getInstance().gameRenderer.getFeatureRenderDispatcher().getSubmitNodeStorage(),
-				cameraRenderState
-			);
+			.submit(renderState.blockEntityRenderState(), poseStack, submitNodeCollector, cameraRenderState);
 	}
 
 	@Override

--- a/catnip/common/src/client/java/net/createmod/catnip/impl/client/gui/element/pip/GuiBlockModelRenderer.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/impl/client/gui/element/pip/GuiBlockModelRenderer.java
@@ -3,51 +3,30 @@ package net.createmod.catnip.impl.client.gui.element.pip;
 import com.mojang.blaze3d.vertex.PoseStack;
 
 import net.createmod.catnip.api.client.gui.render.pip.GuiBlockModelRenderState;
-import net.createmod.catnip.api.client.level.SinglePosVirtualBlockGetter;
 import net.createmod.catnip.api.client.render.model.BakedModelBufferer;
-import net.createmod.catnip.impl.client.render.ColoringVertexConsumer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.render.pip.PictureInPictureRenderer;
-import net.minecraft.client.renderer.MultiBufferSource.BufferSource;
-import net.minecraft.client.renderer.Sheets;
-import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
-import net.minecraft.client.renderer.rendertype.RenderType;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.core.BlockPos;
-import net.minecraft.util.ARGB;
 
 public class GuiBlockModelRenderer extends PictureInPictureRenderer<GuiBlockModelRenderState> {
-	public GuiBlockModelRenderer(BufferSource bufferSource) {
-		super(bufferSource);
-	}
-
 	@Override
 	public Class<GuiBlockModelRenderState> getRenderStateClass() {
 		return GuiBlockModelRenderState.class;
 	}
 
 	@Override
-	protected void renderToTexture(GuiBlockModelRenderState renderState, PoseStack poseStack) {
-		SinglePosVirtualBlockGetter level = SinglePosVirtualBlockGetter.createFullBright();
-		level.blockState(renderState.state());
-		level.blockEntity(renderState.blockEntity());
-
-		int color = renderState.color();
-		BakedModelBufferer.bufferModel(Minecraft.getInstance().getModelManager().getBlockStateModelSet().get(renderState.state()), BlockPos.ZERO, level, renderState.state(),
-			poseStack, (layer, shade) -> {
-				RenderType type = layer == ChunkSectionLayer.TRANSLUCENT
-					? Sheets.translucentBlockItemSheet()
-					: Sheets.cutoutBlockSheet();
-
-				return new ColoringVertexConsumer(
-					bufferSource.getBuffer(type),
-					ARGB.red(color) / 255f,
-					ARGB.green(color) / 255f,
-					ARGB.blue(color) / 255f,
-					1);
-			}
+	protected void renderToTexture(GuiBlockModelRenderState renderState, PoseStack poseStack, SubmitNodeCollector submitNodeCollector) {
+		BakedModelBufferer.submitModel(
+			Minecraft.getInstance().getModelManager().getBlockStateModelSet().get(renderState.state()),
+			BlockPos.ZERO,
+			renderState.state(),
+			poseStack,
+			(layer, shade) -> {
+				throw new UnsupportedOperationException("GUI block model submission should not request direct buffers");
+			},
+			submitNodeCollector
 		);
-
-		bufferSource.endBatch();
 	}
 
 	@Override

--- a/catnip/common/src/client/java/net/createmod/catnip/impl/client/gui/element/pip/GuiFluidStateRenderer.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/impl/client/gui/element/pip/GuiFluidStateRenderer.java
@@ -5,21 +5,17 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.createmod.catnip.api.client.gui.render.pip.GuiFluidStateRenderState;
 import net.createmod.catnip.api.client.platform.ModClientHooksHelper;
 import net.minecraft.client.gui.render.pip.PictureInPictureRenderer;
-import net.minecraft.client.renderer.MultiBufferSource.BufferSource;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 
 public class GuiFluidStateRenderer extends PictureInPictureRenderer<GuiFluidStateRenderState> {
-	public GuiFluidStateRenderer(BufferSource bufferSource) {
-		super(bufferSource);
-	}
-
 	@Override
 	public Class<GuiFluidStateRenderState> getRenderStateClass() {
 		return GuiFluidStateRenderState.class;
 	}
 
 	@Override
-	protected void renderToTexture(GuiFluidStateRenderState renderState, PoseStack poseStack) {
-		ModClientHooksHelper.INSTANCE.renderFullFluidState(poseStack, this.bufferSource, renderState.fluidState());
+	protected void renderToTexture(GuiFluidStateRenderState renderState, PoseStack poseStack, SubmitNodeCollector submitNodeCollector) {
+		ModClientHooksHelper.INSTANCE.submitFullFluidState(poseStack, submitNodeCollector, renderState.fluidState());
 	}
 
 	@Override

--- a/catnip/common/src/client/java/net/createmod/catnip/impl/client/placement/PlacementClient.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/impl/client/placement/PlacementClient.java
@@ -15,6 +15,7 @@ import net.createmod.catnip.api.animation.LerpedFloat;
 import net.createmod.catnip.api.client.gui.render.FadedArrowRenderState;
 import net.createmod.catnip.api.client.gui.render.TexturedArrowRenderState;
 import net.createmod.catnip.api.client.gui.texture.CatnipGuiTextures;
+import net.createmod.catnip.api.client.placement.PlacementAssistConfig;
 import net.createmod.catnip.api.client.placement.PlacementHelperRenderer;
 import net.createmod.catnip.api.math.AngleHelper;
 import net.createmod.catnip.api.math.VecHelper;
@@ -188,13 +189,12 @@ public class PlacementClient {
 
 		float length = 10;
 
-		// FIXME: config
-		// CClient.PlacementIndicatorSetting mode = PonderConfig.client().placementIndicator.get();
-		// if (mode == CClient.PlacementIndicatorSetting.TRIANGLE) {
-			// fadedArrow(graphics, centerX, centerY, r, g, b, a, length);
-		// } else if (mode == CClient.PlacementIndicatorSetting.TEXTURE) {
+		PlacementAssistConfig.IndicatorSetting mode = PlacementAssistConfig.get().placementIndicator();
+		if (mode == PlacementAssistConfig.IndicatorSetting.TRIANGLE) {
+			fadedArrow(graphics, centerX, centerY, r, g, b, a, length);
+		} else if (mode == PlacementAssistConfig.IndicatorSetting.TEXTURE) {
 			textured(graphics, centerX, centerY, a, snappedAngle);
-		// }
+		}
 	}
 
 	private static void fadedArrow(GuiGraphicsExtractor graphics, float centerX, float centerY, float r, float g, float b, float a, float length) {
@@ -202,8 +202,7 @@ public class PlacementClient {
 		poseStack.pushMatrix();
 		poseStack.translate(centerX, centerY);
 		poseStack.rotate(angle.getValue(0) * Constants.DEG_TO_RAD);
-		// FIXME: config
-		double scale = 1;//PonderConfig.client().indicatorScale.get();
+		double scale = PlacementAssistConfig.get().indicatorScale();
 		poseStack.scale((float) scale, (float) scale);
 
 		int size = (int) ((10 + length) * scale);
@@ -218,8 +217,7 @@ public class PlacementClient {
 		Matrix3x2fStack poseStack = graphics.pose();
 		poseStack.pushMatrix();
 		poseStack.translate(centerX, centerY);
-		// FIXME: config
-		float scale = /*PonderConfig.client().indicatorScale.get().floatValue()*/ 1 * .75f;
+		float scale = PlacementAssistConfig.get().indicatorScale() * .75f;
 		poseStack.scale(scale, scale);
 		poseStack.scale(12, 12);
 
@@ -254,7 +252,7 @@ public class PlacementClient {
 		 * Result is (dist right of center screen, dist up from center screen, if < 0,
 		 * then in front of view plane)
 		 */
-		Camera ari = Minecraft.getInstance().gameRenderer.getMainCamera();
+		Camera ari = Minecraft.getInstance().gameRenderer.mainCamera();
 		Vec3 cameraPos = ari.position();
 		Quaternionf cameraRotationConj = new Quaternionf(ari.rotation());
 		cameraRotationConj.conjugate();

--- a/catnip/common/src/client/java/net/createmod/catnip/impl/client/render/model/MeshEmitter.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/impl/client/render/model/MeshEmitter.java
@@ -7,6 +7,7 @@ import com.mojang.blaze3d.vertex.BufferBuilder;
 import com.mojang.blaze3d.vertex.ByteBufferBuilder;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.PrimitiveTopology;
 
 import net.createmod.catnip.api.client.render.model.ShadeSeparatedResultConsumer;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
@@ -45,10 +46,10 @@ class MeshEmitter {
 
 	private void prepareForGeometry(boolean shade) {
 		if (bufferBuilder == null) {
-			bufferBuilder = new BufferBuilder(byteBufferBuilder, VertexFormat.Mode.QUADS, DefaultVertexFormat.BLOCK);
+			bufferBuilder = new BufferBuilder(byteBufferBuilder, PrimitiveTopology.QUADS, DefaultVertexFormat.BLOCK);
 		} else if (shade != currentShade) {
 			emit();
-			bufferBuilder = new BufferBuilder(byteBufferBuilder, VertexFormat.Mode.QUADS, DefaultVertexFormat.BLOCK);
+			bufferBuilder = new BufferBuilder(byteBufferBuilder, PrimitiveTopology.QUADS, DefaultVertexFormat.BLOCK);
 		}
 
 		currentShade = shade;

--- a/catnip/common/src/client/java/net/createmod/catnip/net/base/ClientboundPacketRegistryBridge.java
+++ b/catnip/common/src/client/java/net/createmod/catnip/net/base/ClientboundPacketRegistryBridge.java
@@ -1,0 +1,15 @@
+package net.createmod.catnip.net.base;
+
+import net.createmod.catnip.api.client.network.ClientNetworkHelper;
+
+final class ClientboundPacketRegistryBridge {
+	private ClientboundPacketRegistryBridge() {
+	}
+
+	static <T extends BasePacketPayload> void register(CatnipPacketRegistry.PacketType<T> packet) {
+		if (!ClientboundPacketPayload.class.isAssignableFrom(packet.clazz()))
+			return;
+		ClientNetworkHelper.INSTANCE.registerPayloadHandler(packet.type(),
+			(payload, player) -> ((ClientboundPacketPayload) payload).handle(player));
+	}
+}

--- a/catnip/common/src/main/java/net/createmod/catnip/api/config/ConfigHelper.java
+++ b/catnip/common/src/main/java/net/createmod/catnip/api/config/ConfigHelper.java
@@ -203,8 +203,8 @@ public class ConfigHelper {
 	}
 
 	public static class ConfigChange {
-		Object value;
-		Map<String, String> annotations = new HashMap<>();
+		public final Object value;
+		public final Map<String, String> annotations = new HashMap<>();
 
 		ConfigChange(Object value) {
 			this.value = value;

--- a/catnip/common/src/main/java/net/createmod/catnip/api/data/TriState.java
+++ b/catnip/common/src/main/java/net/createmod/catnip/api/data/TriState.java
@@ -1,0 +1,11 @@
+package net.createmod.catnip.api.data;
+
+public enum TriState {
+	TRUE,
+	FALSE,
+	DEFAULT;
+
+	public boolean get() {
+		return this == TRUE;
+	}
+}

--- a/catnip/common/src/main/java/net/createmod/catnip/api/lang/LangBuilder.java
+++ b/catnip/common/src/main/java/net/createmod/catnip/api/lang/LangBuilder.java
@@ -167,6 +167,19 @@ public class LangBuilder {
 		tooltip.add(component());
 	}
 
+	public void forGoggles(List<Component> tooltip) {
+		forGoggles(tooltip, 0);
+	}
+
+	public void forGoggles(List<Component> tooltip, int indents) {
+		MutableComponent component = component();
+		if (indents <= 0) {
+			tooltip.add(component);
+			return;
+		}
+		tooltip.add(Component.literal("  ".repeat(indents)).append(component));
+	}
+
 	//
 
 	private void assertComponent() {

--- a/catnip/common/src/main/java/net/createmod/catnip/api/nbt/NBTHelper.java
+++ b/catnip/common/src/main/java/net/createmod/catnip/api/nbt/NBTHelper.java
@@ -6,11 +6,17 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.FloatTag;
 import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.Unit;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.phys.AABB;
 
 // TODO - Everything here needs to be rethought with how codecs exist now and should be used everywhere they can
 @Deprecated(forRemoval = true)
@@ -49,8 +55,77 @@ public class NBTHelper {
 		return list;
 	}
 
+	public static ListTag writeItemList(Iterable<ItemStack> list, HolderLookup.Provider registries) {
+		ListTag listNBT = new ListTag();
+		list.forEach(stack -> {
+			if (stack.isEmpty())
+				return;
+			ItemStack.OPTIONAL_CODEC.encodeStart(registries.createSerializationContext(NbtOps.INSTANCE), stack)
+				.result()
+				.ifPresent(listNBT::add);
+		});
+		return listNBT;
+	}
+
+	public static List<ItemStack> readItemList(ListTag listNBT, HolderLookup.Provider registries) {
+		List<ItemStack> list = new ArrayList<>(listNBT.size());
+		listNBT.forEach(tag -> ItemStack.OPTIONAL_CODEC
+			.parse(registries.createSerializationContext(NbtOps.INSTANCE), tag)
+			.result()
+			.filter(stack -> !stack.isEmpty())
+			.ifPresent(list::add));
+		return list;
+	}
+
 	public static void iterateCompoundList(ListTag listNBT, Consumer<CompoundTag> consumer) {
 		listNBT.forEach(inbt -> consumer.accept((CompoundTag) inbt));
+	}
+
+	public static <T extends Enum<T>> void writeEnum(CompoundTag nbt, String key, T value) {
+		nbt.putString(key, value.name());
+	}
+
+	public static <T extends Enum<T>> T readEnum(CompoundTag nbt, String key, Class<T> enumClass) {
+		String value = nbt.getStringOr(key, "");
+		try {
+			return Enum.valueOf(enumClass, value);
+		} catch (IllegalArgumentException e) {
+			T[] constants = enumClass.getEnumConstants();
+			if (constants == null || constants.length == 0)
+				throw e;
+			return constants[0];
+		}
+	}
+
+	public static void writeIdentifier(CompoundTag nbt, String key, Identifier value) {
+		nbt.putString(key, value.toString());
+	}
+
+	public static Identifier readIdentifier(CompoundTag nbt, String key) {
+		Identifier identifier = Identifier.tryParse(nbt.getStringOr(key, ""));
+		return identifier == null ? Identifier.withDefaultNamespace("missing") : identifier;
+	}
+
+	public static ListTag writeAABB(AABB bb) {
+		ListTag list = new ListTag();
+		list.add(FloatTag.valueOf((float) bb.minX));
+		list.add(FloatTag.valueOf((float) bb.minY));
+		list.add(FloatTag.valueOf((float) bb.minZ));
+		list.add(FloatTag.valueOf((float) bb.maxX));
+		list.add(FloatTag.valueOf((float) bb.maxY));
+		list.add(FloatTag.valueOf((float) bb.maxZ));
+		return list;
+	}
+
+	public static AABB readAABB(ListTag list) {
+		return new AABB(
+			list.getFloatOr(0, 0),
+			list.getFloatOr(1, 0),
+			list.getFloatOr(2, 0),
+			list.getFloatOr(3, 0),
+			list.getFloatOr(4, 0),
+			list.getFloatOr(5, 0)
+		);
 	}
 
 	public static Tag getINBT(CompoundTag nbt, String id) {

--- a/catnip/common/src/main/java/net/createmod/catnip/api/placement/PlacementOffset.java
+++ b/catnip/common/src/main/java/net/createmod/catnip/api/placement/PlacementOffset.java
@@ -5,7 +5,7 @@ import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 
 import net.createmod.catnip.api.platform.services.ModHooksHelper;
-import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.advancements.triggers.CriteriaTriggers;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
 import net.minecraft.server.level.ServerPlayer;

--- a/catnip/common/src/main/java/net/createmod/catnip/api/platform/CatnipServices.java
+++ b/catnip/common/src/main/java/net/createmod/catnip/api/platform/CatnipServices.java
@@ -1,0 +1,12 @@
+package net.createmod.catnip.api.platform;
+
+import net.createmod.catnip.api.network.NetworkHelper;
+import net.createmod.catnip.api.platform.services.PlatformHelper;
+
+public final class CatnipServices {
+	public static final PlatformHelper PLATFORM = PlatformHelper.INSTANCE;
+	public static final NetworkHelper NETWORK = NetworkHelper.INSTANCE;
+
+	private CatnipServices() {
+	}
+}

--- a/catnip/common/src/main/java/net/createmod/catnip/impl/command/CatnipCommands.java
+++ b/catnip/common/src/main/java/net/createmod/catnip/impl/command/CatnipCommands.java
@@ -16,7 +16,7 @@ public class CatnipCommands {
 
 		LiteralCommandNode<CommandSourceStack> catnipRoot = Commands.literal("catnip")
 			.requires(Commands.hasPermission(Commands.LEVEL_ALL))
-			//.then(ConfigCommand.register()) FIXME: config
+			.then(ConfigCommand.register())
 			.then(util)
 			.build();
 

--- a/catnip/common/src/main/java/net/createmod/catnip/net/base/BasePacketPayload.java
+++ b/catnip/common/src/main/java/net/createmod/catnip/net/base/BasePacketPayload.java
@@ -1,0 +1,16 @@
+package net.createmod.catnip.net.base;
+
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+
+public interface BasePacketPayload extends CustomPacketPayload {
+	PacketTypeProvider getTypeProvider();
+
+	@Override
+	default CustomPacketPayload.Type<? extends CustomPacketPayload> type() {
+		return getTypeProvider().getType();
+	}
+
+	interface PacketTypeProvider {
+		<T extends CustomPacketPayload> CustomPacketPayload.Type<T> getType();
+	}
+}

--- a/catnip/common/src/main/java/net/createmod/catnip/net/base/CatnipPacketRegistry.java
+++ b/catnip/common/src/main/java/net/createmod/catnip/net/base/CatnipPacketRegistry.java
@@ -1,0 +1,60 @@
+package net.createmod.catnip.net.base;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.createmod.catnip.api.platform.Env;
+import net.createmod.catnip.api.platform.services.PlatformHelper;
+import net.createmod.catnip.api.network.NetworkHelper;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+
+public class CatnipPacketRegistry {
+	private final List<PacketType<? extends BasePacketPayload>> packets = new ArrayList<>();
+
+	public CatnipPacketRegistry(String namespace, String version) {
+	}
+
+	public <T extends BasePacketPayload> void registerPacket(PacketType<T> packet) {
+		packets.add(packet);
+	}
+
+	public void registerAllPackets() {
+		for (PacketType<? extends BasePacketPayload> packet : packets) {
+			register(packet);
+		}
+	}
+
+	private <T extends BasePacketPayload> void register(PacketType<T> packet) {
+		if (ServerboundPacketPayload.class.isAssignableFrom(packet.clazz())) {
+			NetworkHelper.INSTANCE.serverboundCodecs().register(packet.type(), packet.codec());
+			NetworkHelper.INSTANCE.registerPayloadHandler(packet.type(),
+				(payload, player) -> ((ServerboundPacketPayload) payload).handle(player));
+			return;
+		}
+
+		NetworkHelper.INSTANCE.clientboundCodecs().register(packet.type(), packet.codec());
+		if (PlatformHelper.INSTANCE.getEnv() == Env.CLIENT) {
+			registerClientHandler(packet);
+		}
+	}
+
+	private static void registerClientHandler(PacketType<?> packet) {
+		try {
+			Class<?> bridgeClass = Class.forName("net.createmod.catnip.net.base.ClientboundPacketRegistryBridge");
+			Method register = bridgeClass.getDeclaredMethod("register", PacketType.class);
+			register.setAccessible(true);
+			register.invoke(null, packet);
+		} catch (ReflectiveOperationException | LinkageError ignored) {
+		}
+	}
+
+	public record PacketType<T extends BasePacketPayload>(
+		CustomPacketPayload.Type<T> type,
+		Class<T> clazz,
+		StreamCodec<? super RegistryFriendlyByteBuf, T> codec
+	) {
+	}
+}

--- a/catnip/common/src/main/java/net/createmod/catnip/net/base/ClientboundPacketPayload.java
+++ b/catnip/common/src/main/java/net/createmod/catnip/net/base/ClientboundPacketPayload.java
@@ -1,0 +1,7 @@
+package net.createmod.catnip.net.base;
+
+import net.minecraft.world.entity.player.Player;
+
+public interface ClientboundPacketPayload extends BasePacketPayload {
+	void handle(Player player);
+}

--- a/catnip/common/src/main/java/net/createmod/catnip/net/base/ServerboundPacketPayload.java
+++ b/catnip/common/src/main/java/net/createmod/catnip/net/base/ServerboundPacketPayload.java
@@ -1,0 +1,9 @@
+package net.createmod.catnip.net.base;
+
+import net.createmod.catnip.api.network.SelfHandlingPayload;
+import net.minecraft.server.level.ServerPlayer;
+
+public interface ServerboundPacketPayload extends BasePacketPayload, SelfHandlingPayload {
+	@Override
+	void handle(ServerPlayer player);
+}

--- a/catnip/fabric/src/client/java/net/createmod/catnip/impl/fabric/client/service/FabricClientHooksHelper.java
+++ b/catnip/fabric/src/client/java/net/createmod/catnip/impl/fabric/client/service/FabricClientHooksHelper.java
@@ -2,7 +2,7 @@ package net.createmod.catnip.impl.fabric.client.service;
 
 import java.util.Iterator;
 import java.util.Locale;
-import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.jspecify.annotations.Nullable;
 
@@ -26,8 +26,7 @@ import net.minecraft.client.gui.render.pip.PictureInPictureRenderer;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.Particle;
-import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.MultiBufferSource.BufferSource;
+import net.createmod.catnip.api.client.render.MultiBufferSource;
 import net.minecraft.client.renderer.OrderedSubmitNodeCollector;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
@@ -65,8 +64,8 @@ public class FabricClientHooksHelper implements ModClientHooksHelper {
 	}
 
 	@Override
-	public void registerPictureInPictureRenderer(Class<?> stateClass, Function<BufferSource, PictureInPictureRenderer<?>> factory) {
-		PictureInPictureRendererRegistry.register(ctx -> factory.apply(ctx.bufferSource()));
+	public void registerPictureInPictureRenderer(Class<?> stateClass, Supplier<PictureInPictureRenderer<?>> factory) {
+		PictureInPictureRendererRegistry.register(ctx -> factory.get());
 	}
 
 	@Override

--- a/catnip/neoforge/src/main/java/net/createmod/catnip/api/client/ConflictSafeKeyMapping.java
+++ b/catnip/neoforge/src/main/java/net/createmod/catnip/api/client/ConflictSafeKeyMapping.java
@@ -1,0 +1,9 @@
+package net.createmod.catnip.api.client;
+
+import net.minecraft.client.KeyMapping;
+
+public class ConflictSafeKeyMapping extends KeyMapping {
+	public ConflictSafeKeyMapping(String name, int key, String category) {
+		super(name, key, Category.MISC);
+	}
+}

--- a/catnip/neoforge/src/main/java/net/createmod/catnip/api/platform/NeoForgeCatnipServices.java
+++ b/catnip/neoforge/src/main/java/net/createmod/catnip/api/platform/NeoForgeCatnipServices.java
@@ -1,0 +1,10 @@
+package net.createmod.catnip.api.platform;
+
+import net.createmod.catnip.api.client.render.FluidRenderHelper;
+
+public final class NeoForgeCatnipServices {
+	public static final FluidRenderHelper FLUID_RENDERER = null;
+
+	private NeoForgeCatnipServices() {
+	}
+}

--- a/catnip/neoforge/src/main/java/net/createmod/catnip/impl/neoforge/CatnipNeoforgeClient.java
+++ b/catnip/neoforge/src/main/java/net/createmod/catnip/impl/neoforge/CatnipNeoforgeClient.java
@@ -1,7 +1,5 @@
 package net.createmod.catnip.impl.neoforge;
 
-import java.util.function.Function;
-
 import net.createmod.catnip.api.Catnip;
 import net.createmod.catnip.api.client.command.ClientCommands;
 import net.createmod.catnip.api.client.event.AtlasStitchedCallback;
@@ -45,7 +43,7 @@ public final class CatnipNeoforgeClient {
 	private static void registerPictureInPictureRenderers(RegisterPictureInPictureRenderersEvent event) {
 		NeoForgeClientHooksHelper.PIP_RENDERERS.forEach((state, factory) -> {
 			//noinspection unchecked,rawtypes
-			event.register((Class<PictureInPictureRenderState>) state, (Function) factory);
+			event.register((Class<PictureInPictureRenderState>) state, (java.util.function.Supplier) factory);
 		});
 	}
 

--- a/catnip/neoforge/src/main/java/net/createmod/catnip/impl/neoforge/render/BakedModelBuffererImpl.java
+++ b/catnip/neoforge/src/main/java/net/createmod/catnip/impl/neoforge/render/BakedModelBuffererImpl.java
@@ -15,7 +15,6 @@ import net.createmod.catnip.api.client.render.model.ShadeSeparatedResultConsumer
 import net.createmod.catnip.impl.client.render.TransformingVertexConsumer;
 import net.createmod.catnip.impl.client.render.model.DefaultShadeSeparatedBufferSource;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.OrderedSubmitNodeCollector;
 import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
@@ -58,7 +57,7 @@ public final class BakedModelBuffererImpl {
 
 		universalEmitter.prepare(bufferSource, model.hasMaterialFlag(BakedQuad.FLAG_TRANSLUCENT) ? ChunkSectionLayer.TRANSLUCENT : ChunkSectionLayer.CUTOUT);
 
-		RenderType layer = model.hasMaterialFlag(BakedQuad.FLAG_TRANSLUCENT) ? Sheets.translucentBlockSheet() : Sheets.cutoutBlockSheet();
+		RenderType layer = model.hasMaterialFlag(BakedQuad.FLAG_TRANSLUCENT) ? Sheets.translucentBlockItemSheet() : Sheets.cutoutBlockItemSheet();
 		List<BlockStateModelPart> parts = new ArrayList<>();
 
 		model.collectParts(RandomSource.create(seed), parts);
@@ -94,7 +93,7 @@ public final class BakedModelBuffererImpl {
 		VertexConsumer buffer = bufferSource.getBuffer(defaultLayer, false);
 
 		QuadInstance instance = new QuadInstance();
-		boolean useAo = Minecraft.getInstance().gameRenderer.getGameRenderState().optionsRenderState.ambientOcclusion;
+		boolean useAo = Minecraft.getInstance().gameRenderer.gameRenderState().optionsRenderState.ambientOcclusion;
 		int light = LightCoordsUtil.pack(level.getBrightness(LightLayer.BLOCK, pos), level.getBrightness(LightLayer.SKY, pos));
 
 		instance.setOverlayCoords(OverlayTexture.NO_OVERLAY);
@@ -184,8 +183,8 @@ public final class BakedModelBuffererImpl {
 				model.collectParts(RandomSource.create(seed), parts);
 
 				QuadInstance instance = new QuadInstance();
-				boolean useAo = Minecraft.getInstance().gameRenderer.getGameRenderState().optionsRenderState.ambientOcclusion;
-				int light = LevelRenderer.getLightCoords(level, pos);
+				boolean useAo = Minecraft.getInstance().gameRenderer.gameRenderState().optionsRenderState.ambientOcclusion;
+				int light = LightCoordsUtil.getLightCoords(level, pos);
 
 				instance.setOverlayCoords(OverlayTexture.NO_OVERLAY);
 

--- a/catnip/neoforge/src/main/java/net/createmod/catnip/impl/neoforge/render/VirtualRenderHelper.java
+++ b/catnip/neoforge/src/main/java/net/createmod/catnip/impl/neoforge/render/VirtualRenderHelper.java
@@ -1,9 +1,13 @@
 package net.createmod.catnip.impl.neoforge.render;
 
+import java.util.List;
+import java.util.function.ToIntFunction;
+
 import dev.engine_room.flywheel.api.model.Model;
 import dev.engine_room.flywheel.lib.model.baked.BlockModelBuilder;
+import dev.engine_room.flywheel.lib.model.baked.SinglePosVirtualBlockGetter;
 import dev.engine_room.flywheel.lib.util.RendererReloadCache;
-import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.state.BlockState;
 
 import net.neoforged.neoforge.model.data.ModelData;
@@ -13,7 +17,7 @@ public class VirtualRenderHelper {
 	public static final ModelProperty<Boolean> VIRTUAL_PROPERTY = new ModelProperty<>();
 	public static final ModelData VIRTUAL_DATA = ModelData.builder().with(VIRTUAL_PROPERTY, true).build();
 
-	private static final RendererReloadCache<BlockState, Model> VIRTUAL_BLOCKS = new RendererReloadCache<>(state -> new BlockModelBuilder(Minecraft.getInstance().getModelManager().getBlockStateModelSet().get(state)).build());
+	private static final RendererReloadCache<BlockState, Model> VIRTUAL_BLOCKS = new RendererReloadCache<>(state -> new BlockModelBuilder(new VirtualBlockGetter(state), List.of(BlockPos.ZERO)).build());
 
 	public static boolean isVirtual(ModelData data) {
 		return data.has(VirtualRenderHelper.VIRTUAL_PROPERTY) && Boolean.TRUE.equals(data.get(VirtualRenderHelper.VIRTUAL_PROPERTY));
@@ -28,4 +32,16 @@ public class VirtualRenderHelper {
 		return VIRTUAL_BLOCKS.get(state);
 	}
 
+	private static class VirtualBlockGetter extends SinglePosVirtualBlockGetter {
+		private static final ToIntFunction<BlockPos> DARK_LIGHT = pos -> 0;
+
+		VirtualBlockGetter(BlockState state) {
+			super(DARK_LIGHT, DARK_LIGHT);
+			blockState(state);
+		}
+
+		public ModelData getModelData(BlockPos pos) {
+			return BlockPos.ZERO.equals(pos) ? VIRTUAL_DATA : ModelData.EMPTY;
+		}
+	}
 }

--- a/catnip/neoforge/src/main/java/net/createmod/catnip/impl/neoforge/service/NeoForgeClientHooksHelper.java
+++ b/catnip/neoforge/src/main/java/net/createmod/catnip/impl/neoforge/service/NeoForgeClientHooksHelper.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.jetbrains.annotations.ApiStatus.Internal;
@@ -31,8 +30,7 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.ParticleProvider;
-import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.MultiBufferSource.BufferSource;
+import net.createmod.catnip.api.client.render.MultiBufferSource;
 import net.minecraft.client.renderer.OrderedSubmitNodeCollector;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
@@ -47,7 +45,7 @@ public class NeoForgeClientHooksHelper implements ModClientHooksHelper {
 	private static final Supplier<Map<Identifier, ParticleProvider<?>>> particleProviders = () -> Minecraft.getInstance().particleEngine.resourceManager.getProviders();
 
 	@Internal
-	public static final Map<Class<?>, Function<BufferSource, PictureInPictureRenderer<?>>> PIP_RENDERERS = new HashMap<>();
+	public static final Map<Class<?>, Supplier<PictureInPictureRenderer<?>>> PIP_RENDERERS = new HashMap<>();
 
 	@Override
 	public Locale getCurrentLocale() {
@@ -77,7 +75,7 @@ public class NeoForgeClientHooksHelper implements ModClientHooksHelper {
 	}
 
 	@Override
-	public void registerPictureInPictureRenderer(Class<?> stateClass, Function<BufferSource, PictureInPictureRenderer<?>> factory) {
+	public void registerPictureInPictureRenderer(Class<?> stateClass, Supplier<PictureInPictureRenderer<?>> factory) {
 		PIP_RENDERERS.put(stateClass, factory);
 	}
 

--- a/catnip/neoforge/src/main/java/net/createmod/catnip/impl/neoforge/service/NeoForgeClientNetworkHelper.java
+++ b/catnip/neoforge/src/main/java/net/createmod/catnip/impl/neoforge/service/NeoForgeClientNetworkHelper.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import net.createmod.catnip.api.client.network.ClientNetworkHelper;
 import net.createmod.catnip.api.client.network.ClientboundPayloadHandler;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload.Type;
 
@@ -38,7 +37,7 @@ public class NeoForgeClientNetworkHelper implements ClientNetworkHelper {
 				return;
 
 			e.register(type, ((payload, context) -> {
-				((ClientboundPayloadHandler) handler).handle(payload, (LocalPlayer) context.player());
+				((ClientboundPayloadHandler) handler).handle(payload, context.player());
 			}));
 		});
 	}

--- a/catnip/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/catnip/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -15,12 +15,6 @@ credits = "${contributors}"
 [[mixins]]
 config = "catnip-common.mixins.json"
 
-[[mixins]]
-config = "catnip-common-client.mixins.json"
-
-[[mixins]]
-config = "catnip-neoforge.mixins.json"
-
 [[dependencies.catnip]]
 modId = "neoforge"
 type="required"

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
 dependencies {
     minecraft(libs.minecraft)
     compileOnly(libs.bundles.mixin)
+    compileOnlyApi(libs.bundles.neoforge.config)
+    clientCompileOnly(libs.bundles.neoforge.config)
     compileOnlyApi(project(":catnip:common"))
     clientCompileOnly(project(":catnip:common", configuration = "clientJar"))
 }

--- a/common/src/client/java/net/createmod/ponder/api/client/PonderIndex.java
+++ b/common/src/client/java/net/createmod/ponder/api/client/PonderIndex.java
@@ -22,6 +22,7 @@ import net.createmod.ponder.impl.client.registration.DefaultSharedTextRegistrati
 import net.createmod.ponder.impl.client.registration.PonderLocalization;
 import net.createmod.ponder.impl.client.registration.PonderSceneRegistry;
 import net.createmod.ponder.impl.client.registration.PonderTagRegistry;
+import net.createmod.ponder.impl.config.PonderConfig;
 
 public class PonderIndex {
 
@@ -97,7 +98,6 @@ public class PonderIndex {
 	}
 
 	public static boolean editingModeActive() {
-		// FIXME: config
-		return true;//PonderConfig.client().editingMode.get();
+		return PonderConfig.client().editingMode.get();
 	}
 }

--- a/common/src/client/java/net/createmod/ponder/api/client/element/ParrotPose.java
+++ b/common/src/client/java/net/createmod/ponder/api/client/element/ParrotPose.java
@@ -11,7 +11,7 @@ import net.createmod.ponder.impl.mixin.ParrotAccessor;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
-import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.entity.animal.parrot.Parrot;
 import net.minecraft.world.phys.Vec3;
 
@@ -27,7 +27,7 @@ public abstract class ParrotPose {
 	public abstract void tick(PonderScene scene, Parrot entity, Vec3 location);
 
 	public Parrot create(PonderLevel world) {
-		Parrot entity = new Parrot(EntityType.PARROT, world);
+		Parrot entity = new Parrot(EntityTypes.PARROT, world);
 		int nextInt = Ponder.RANDOM.nextInt(VARIANTS.length);
 		((ParrotAccessor) entity).ponder$setVariant(VARIANTS[nextInt]);
 		return entity;

--- a/common/src/client/java/net/createmod/ponder/api/client/element/PonderSceneElement.java
+++ b/common/src/client/java/net/createmod/ponder/api/client/element/PonderSceneElement.java
@@ -4,7 +4,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 
 import net.createmod.ponder.api.client.level.PonderLevel;
 import net.minecraft.client.Camera;
-import net.minecraft.client.renderer.MultiBufferSource;
+import net.createmod.catnip.api.client.render.MultiBufferSource;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.state.level.CameraRenderState;

--- a/common/src/client/java/net/createmod/ponder/api/client/level/PonderLevel.java
+++ b/common/src/client/java/net/createmod/ponder/api/client/level/PonderLevel.java
@@ -27,7 +27,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.SubmitNodeCollector;
-import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
@@ -40,6 +39,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.Mth;
 import net.minecraft.util.ProblemReporter;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntitySpawnRequest;
 import net.minecraft.world.entity.EntitySpawnReason;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
@@ -97,7 +97,7 @@ public class PonderLevel extends SchematicLevel implements BlockAndTintGetter {
 				TagValueOutput output = TagValueOutput.createWithContext(reporter, registryAccess());
 				e.save(output);
 				ValueInput input = TagValueInput.create(reporter, registryAccess(), output.buildResult());
-				EntityType.create(input, this, EntitySpawnReason.LOAD).ifPresent(originalEntities::add);
+				EntityType.create(input, this, new EntitySpawnRequest(EntitySpawnReason.LOAD, false)).ifPresent(originalEntities::add);
 			}
 		});
 	}
@@ -120,7 +120,7 @@ public class PonderLevel extends SchematicLevel implements BlockAndTintGetter {
 				TagValueOutput output = TagValueOutput.createWithContext(reporter, registryAccess());
 				e.save(output);
 				ValueInput input = TagValueInput.create(reporter, registryAccess(), output.buildResult());
-				EntityType.create(input, this, EntitySpawnReason.LOAD).ifPresent(originalEntities::add);
+				EntityType.create(input, this, new EntitySpawnRequest(EntitySpawnReason.LOAD, false)).ifPresent(entities::add);
 			}
 		});
 		particles.clearEffects();
@@ -233,7 +233,7 @@ public class PonderLevel extends SchematicLevel implements BlockAndTintGetter {
 		}
 	}
 
-	public void renderParticles(PoseStack ms, SubmitNodeStorage queue, Camera camera,
+	public void renderParticles(PoseStack ms, SubmitNodeCollector queue, Camera camera,
 								CameraRenderState cameraRenderState, float pt) {
 		particles.renderParticles(ms, queue, camera, cameraRenderState, pt);
 	}

--- a/common/src/client/java/net/createmod/ponder/api/client/registration/PonderTag.java
+++ b/common/src/client/java/net/createmod/ponder/api/client/registration/PonderTag.java
@@ -11,6 +11,7 @@ import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
 
 public class PonderTag implements ScreenElement {
 	/**
@@ -24,6 +25,10 @@ public class PonderTag implements ScreenElement {
 	private final Identifier id;
 	@Nullable
 	private final Identifier textureIconLocation;
+	@Nullable
+	private final ItemLike itemIconSource;
+	@Nullable
+	private final ItemLike mainItemSource;
 	private final ItemStack itemIcon;
 	private final ItemStack mainItem;
 
@@ -32,8 +37,20 @@ public class PonderTag implements ScreenElement {
 					 ItemStack mainItem) {
 		this.id = id;
 		this.textureIconLocation = textureIconLocation;
+		this.itemIconSource = null;
+		this.mainItemSource = null;
 		this.itemIcon = itemIcon;
 		this.mainItem = mainItem;
+	}
+
+	public PonderTag(Identifier id, @Nullable Identifier textureIconLocation, @Nullable ItemLike itemIcon,
+					 @Nullable ItemLike mainItem) {
+		this.id = id;
+		this.textureIconLocation = textureIconLocation;
+		this.itemIconSource = itemIcon;
+		this.mainItemSource = mainItem;
+		this.itemIcon = ItemStack.EMPTY;
+		this.mainItem = ItemStack.EMPTY;
 	}
 
 	public Identifier getId() {
@@ -41,6 +58,8 @@ public class PonderTag implements ScreenElement {
 	}
 
 	public ItemStack getMainItem() {
+		if (mainItemSource != null)
+			return new ItemStack(mainItemSource);
 		return mainItem;
 	}
 
@@ -59,8 +78,11 @@ public class PonderTag implements ScreenElement {
 		if (textureIconLocation != null) {
 			poseStack.scale(0.25f, 0.25f);
 			graphics.blit(RenderPipelines.GUI_TEXTURED, textureIconLocation, 0, 0, 0, 0, 0, 64, 64, 64, 64);
-		} else if (!itemIcon.isEmpty()) {
-			GuiGameElement.of(itemIcon)
+		} else {
+			ItemStack stack = itemIconSource != null ? new ItemStack(itemIconSource) : itemIcon;
+			if (stack.isEmpty())
+				return;
+			GuiGameElement.of(stack)
 				.scale(1.25f)
 				.at(-2, -2)
 				.submit(graphics);

--- a/common/src/client/java/net/createmod/ponder/api/client/scene/PonderScene.java
+++ b/common/src/client/java/net/createmod/ponder/api/client/scene/PonderScene.java
@@ -50,7 +50,7 @@ import net.createmod.ponder.impl.client.registration.PonderLocalization;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-import net.minecraft.client.renderer.SubmitNodeStorage;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.core.BlockPos;
@@ -261,7 +261,7 @@ public class PonderScene {
 		activeSchedule.add(new HideAllInstruction(10, null));
 	}
 
-	public void renderScene(SuperRenderTypeBuffer buffer, SubmitNodeStorage queue, PoseStack poseStack, float pt) {
+	public void renderScene(SuperRenderTypeBuffer buffer, SubmitNodeCollector queue, PoseStack poseStack, float pt) {
 		Minecraft mc = Minecraft.getInstance();
 
 		poseStack.pushPose();

--- a/common/src/client/java/net/createmod/ponder/impl/client/PonderClient.java
+++ b/common/src/client/java/net/createmod/ponder/impl/client/PonderClient.java
@@ -1,6 +1,7 @@
 package net.createmod.ponder.impl.client;
 
 import net.createmod.catnip.api.client.platform.ModClientHooksHelper;
+import net.createmod.catnip.api.client.placement.PlacementAssistConfig;
 import net.createmod.catnip.api.client.render.SuperByteBufferCache;
 import net.createmod.catnip.api.platform.services.PlatformHelper;
 import net.createmod.catnip.impl.network.ClientboundSimpleActionPacket;
@@ -11,6 +12,7 @@ import net.createmod.ponder.impl.client.gui.PonderSceneRenderer;
 import net.createmod.ponder.impl.client.plugin.BasePonderPlugin;
 import net.createmod.ponder.impl.client.plugin.DebugPonderPlugin;
 import net.createmod.ponder.impl.client.tooltip.PonderTooltipHandler;
+import net.createmod.ponder.impl.config.PonderConfig;
 
 public class PonderClient {
 	public static void init() {
@@ -20,6 +22,17 @@ public class PonderClient {
 		ClientboundSimpleActionPacket.addAction("reloadPonder", () -> SimplePonderActions::reloadPonder);
 
 		ModClientHooksHelper.INSTANCE.registerPictureInPictureRenderer(PonderSceneRenderState.class, PonderSceneRenderer::new);
+		PlacementAssistConfig.setProvider(new PlacementAssistConfig.Provider() {
+			@Override
+			public PlacementAssistConfig.IndicatorSetting placementIndicator() {
+				return PlacementAssistConfig.IndicatorSetting.valueOf(PonderConfig.client().placementIndicator.get().name());
+			}
+
+			@Override
+			public float indicatorScale() {
+				return PonderConfig.client().indicatorScale.getF();
+			}
+		});
 
 		PonderTooltipHandler.init();
 

--- a/common/src/client/java/net/createmod/ponder/impl/client/element/AnimatedSceneElementBase.java
+++ b/common/src/client/java/net/createmod/ponder/impl/client/element/AnimatedSceneElementBase.java
@@ -10,7 +10,7 @@ import net.createmod.catnip.api.animation.LerpedFloat;
 import net.createmod.ponder.api.client.element.AnimatedSceneElement;
 import net.createmod.ponder.api.client.level.PonderLevel;
 import net.minecraft.client.Camera;
-import net.minecraft.client.renderer.MultiBufferSource;
+import net.createmod.catnip.api.client.render.MultiBufferSource;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.util.LightCoordsUtil;

--- a/common/src/client/java/net/createmod/ponder/impl/client/element/MinecartElementImpl.java
+++ b/common/src/client/java/net/createmod/ponder/impl/client/element/MinecartElementImpl.java
@@ -13,7 +13,7 @@ import net.createmod.ponder.api.client.level.PonderLevel;
 import net.createmod.ponder.api.client.scene.PonderScene;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.MultiBufferSource;
+import net.createmod.catnip.api.client.render.MultiBufferSource;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;

--- a/common/src/client/java/net/createmod/ponder/impl/client/element/ParrotElementImpl.java
+++ b/common/src/client/java/net/createmod/ponder/impl/client/element/ParrotElementImpl.java
@@ -16,7 +16,7 @@ import net.createmod.ponder.api.client.level.PonderLevel;
 import net.createmod.ponder.api.client.scene.PonderScene;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.MultiBufferSource;
+import net.createmod.catnip.api.client.render.MultiBufferSource;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;

--- a/common/src/client/java/net/createmod/ponder/impl/client/element/TrackedElementBase.java
+++ b/common/src/client/java/net/createmod/ponder/impl/client/element/TrackedElementBase.java
@@ -8,7 +8,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.createmod.ponder.api.client.element.TrackedElement;
 import net.createmod.ponder.api.client.level.PonderLevel;
 import net.minecraft.client.Camera;
-import net.minecraft.client.renderer.MultiBufferSource;
+import net.createmod.catnip.api.client.render.MultiBufferSource;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.state.level.CameraRenderState;

--- a/common/src/client/java/net/createmod/ponder/impl/client/element/WorldSectionElementImpl.java
+++ b/common/src/client/java/net/createmod/ponder/impl/client/element/WorldSectionElementImpl.java
@@ -34,9 +34,10 @@ import net.createmod.ponder.api.client.scene.PonderScene;
 import net.createmod.ponder.api.client.scene.Selection;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.MultiBufferSource;
+import net.createmod.catnip.api.client.render.MultiBufferSource;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
@@ -45,6 +46,7 @@ import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.CardinalLighting;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
@@ -355,7 +357,9 @@ public class WorldSectionElementImpl extends AnimatedSceneElementBase implements
 			poseStack.translate(pos.getX(), pos.getY(), pos.getZ());
 			BlockState state = level.getBlockState(pos);
 			BlockStateModel model = Minecraft.getInstance().getModelManager().getBlockStateModelSet().get(state);
-			queue.submitBreakingBlockModel(poseStack, model, state.getSeed(pos), progress);
+			List<BlockStateModelPart> parts = new ArrayList<>();
+			model.collectParts(RandomSource.create(state.getSeed(pos)), parts);
+			queue.submitBreakingBlockModel(poseStack, parts, progress);
 			poseStack.popPose();
 		}
 

--- a/common/src/client/java/net/createmod/ponder/impl/client/gui/PonderSceneRenderer.java
+++ b/common/src/client/java/net/createmod/ponder/impl/client/gui/PonderSceneRenderer.java
@@ -1,9 +1,6 @@
 package net.createmod.ponder.impl.client.gui;
 
-import org.joml.Matrix4f;
-
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
 
 import net.createmod.catnip.api.client.gui.UIRenderHelper;
@@ -16,32 +13,23 @@ import net.createmod.ponder.api.client.scene.PonderScene.SceneTransform;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.render.pip.PictureInPictureRenderer;
 import net.minecraft.client.renderer.GameRenderer;
-import net.minecraft.client.renderer.MultiBufferSource.BufferSource;
-import net.minecraft.client.renderer.SubmitNodeStorage;
-import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 
 public class PonderSceneRenderer extends PictureInPictureRenderer<PonderSceneRenderState> {
-	public PonderSceneRenderer(BufferSource bufferSource) {
-		super(bufferSource);
-	}
-
 	@Override
-	protected void renderToTexture(PonderSceneRenderState state, PoseStack poseStack) {
+	protected void renderToTexture(PonderSceneRenderState state, PoseStack poseStack, SubmitNodeCollector submitNodeCollector) {
 		Minecraft mc = Minecraft.getInstance();
 		GameRenderer gameRenderer = mc.gameRenderer;
-		FeatureRenderDispatcher renderDispatcher = gameRenderer.getFeatureRenderDispatcher();
 
-		SubmitNodeStorage queue = renderDispatcher.getSubmitNodeStorage();
 		poseStack.pushPose();
 		poseStack.setIdentity();
 
-		renderScene(state, poseStack, queue);
-		renderDispatcher.renderAllFeatures();
+		renderScene(state, poseStack, submitNodeCollector);
 
 		poseStack.popPose();
 	}
 
-	private void renderScene(PonderSceneRenderState state, PoseStack poseStack, SubmitNodeStorage queue) {
+	private void renderScene(PonderSceneRenderState state, PoseStack poseStack, SubmitNodeCollector queue) {
 		float partialTicks = state.partialTicks();
 		SuperRenderTypeBuffer buffer = DefaultSuperRenderTypeBuffer.getInstance();
 		PonderScene scene = state.scene();
@@ -77,11 +65,11 @@ public class PonderSceneRenderer extends PictureInPictureRenderer<PonderSceneRen
 				if (flash > 0) {
 					poseStack.pushPose();
 					poseStack.scale(1, .5f + flash * .75f, 1);
-					fillGradient(poseStack, 0, -1, -scene.getBasePlateSize(), 0, new Color(0x00_c6ffc9).getRGB(), new Color(0xaa_c6ffc9).scaleAlpha(alpha).getRGB());
+					fillGradient(queue, poseStack, 0, -1, -scene.getBasePlateSize(), 0, new Color(0x00_c6ffc9).getRGB(), new Color(0xaa_c6ffc9).scaleAlpha(alpha).getRGB());
 					poseStack.popPose();
 				}
 				poseStack.translate(0, 0, 2 / 1024f);
-				fillGradient(poseStack, 0, 0, -scene.getBasePlateSize(), 4, new Color(0x66_000000).getRGB(), new Color(0x00_000000).getRGB());
+				fillGradient(queue, poseStack, 0, 0, -scene.getBasePlateSize(), 4, new Color(0x66_000000).getRGB(), new Color(0x00_000000).getRGB());
 				poseStack.popPose();
 				poseStack.mulPose(Axis.YP.rotationDegrees(-90));
 			}
@@ -141,6 +129,7 @@ public class PonderSceneRenderer extends PictureInPictureRenderer<PonderSceneRen
 	}
 
 	private void fillGradient(
+		SubmitNodeCollector queue,
 		PoseStack poseStack,
 		int x0,
 		int y0,
@@ -149,12 +138,12 @@ public class PonderSceneRenderer extends PictureInPictureRenderer<PonderSceneRen
 		int col1,
 		int col2
 	) {
-		VertexConsumer buffer = bufferSource.getBuffer(PonderRenderTypes.gui());
-		Matrix4f pose = poseStack.last().pose();
-		buffer.addVertex(pose, x0, y0, 0).setColor(col1);
-		buffer.addVertex(pose, x0, y1, 0).setColor(col2);
-		buffer.addVertex(pose, x1, y1, 0).setColor(col2);
-		buffer.addVertex(pose, x1, y0, 0).setColor(col1);
+		queue.submitCustomGeometry(poseStack, PonderRenderTypes.gui(), (pose, buffer) -> {
+			buffer.addVertex(pose, x0, y0, 0).setColor(col1);
+			buffer.addVertex(pose, x0, y1, 0).setColor(col2);
+			buffer.addVertex(pose, x1, y1, 0).setColor(col2);
+			buffer.addVertex(pose, x1, y0, 0).setColor(col1);
+		});
 	}
 
 	@Override

--- a/common/src/client/java/net/createmod/ponder/impl/client/gui/PonderUI.java
+++ b/common/src/client/java/net/createmod/ponder/impl/client/gui/PonderUI.java
@@ -54,6 +54,7 @@ import net.createmod.ponder.impl.client.element.TextWindowElement;
 import net.createmod.ponder.impl.client.gui.element.PonderButton;
 import net.createmod.ponder.impl.client.gui.element.PonderProgressBar;
 import net.createmod.ponder.impl.client.plugin.DebugScenes;
+import net.createmod.ponder.impl.config.PonderConfig;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Options;
@@ -616,7 +617,7 @@ public class PonderUI extends AbstractPonderScreen {
 			slide,
 			finishingFlash,
 			partialTicks,
-			Minecraft.getInstance().gameRenderer.getGameRenderState().windowRenderState
+			Minecraft.getInstance().gameRenderer.gameRenderState().windowRenderState
 		));
 
 		RenderSystem.restoreProjectionMatrix();
@@ -1058,7 +1059,7 @@ public class PonderUI extends AbstractPonderScreen {
 	public static float getPartialTicks() {
 		float renderPartialTicks = AnimationTickHolder.getGuiPartialTicks();
 
-		if (Minecraft.getInstance().screen instanceof PonderUI ui) {
+		if (Minecraft.getInstance().gui.screen() instanceof PonderUI ui) {
 			if (ui.identifyMode)
 				return ponderPartialTicksPaused;
 
@@ -1084,12 +1085,10 @@ public class PonderUI extends AbstractPonderScreen {
 	}
 
 	public boolean isComfyReadingEnabled() {
-		// FIXME: config
-		return false;//PonderConfig.client().comfyReading.get();
+		return PonderConfig.client().comfyReading.get();
 	}
 
 	public void setComfyReadingEnabled(boolean slowTextMode) {
-		// FIXME: config
-		//PonderConfig.client().comfyReading.set(slowTextMode);
+		PonderConfig.client().comfyReading.set(slowTextMode);
 	}
 }

--- a/common/src/client/java/net/createmod/ponder/impl/client/mixin/AbstractContainerScreenAccessor.java
+++ b/common/src/client/java/net/createmod/ponder/impl/client/mixin/AbstractContainerScreenAccessor.java
@@ -9,7 +9,7 @@ import net.minecraft.world.inventory.Slot;
 
 @Mixin(AbstractContainerScreen.class)
 public interface AbstractContainerScreenAccessor {
-	@Accessor
+	@Accessor("hoveredSlot")
 	@Nullable
-	Slot getHoveredSlot();
+	Slot ponder$getHoveredSlot();
 }

--- a/common/src/client/java/net/createmod/ponder/impl/client/plugin/DebugScenes.java
+++ b/common/src/client/java/net/createmod/ponder/impl/client/plugin/DebugScenes.java
@@ -15,6 +15,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.resources.Identifier;
+import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
@@ -87,7 +88,7 @@ public class DebugScenes {
 			.text("Blocks can be modified");
 		scene.idle(20);
 		scene.world().replaceBlocks(util.select().fromTo(1, 1, 3, 2, 2, 4),
-			Blocks.WHITE_CONCRETE.defaultBlockState(), true);
+			Blocks.CONCRETE.pick(DyeColor.WHITE).defaultBlockState(), true);
 		scene.idle(10);
 		scene.addKeyframe();
 		scene.world().replaceBlocks(util.select().position(3, 1, 1), Blocks.REDSTONE_WIRE.defaultBlockState().setValue(RedStoneWireBlock.POWER, 15), true);
@@ -367,7 +368,7 @@ public class DebugScenes {
 
 		scene.world().hideSection(hiddenReplaceArea, Direction.UP);
 		scene.idle(20);
-		scene.world().setBlocks(hiddenReplaceArea, Blocks.BLACK_CONCRETE.defaultBlockState(), false);
+		scene.world().setBlocks(hiddenReplaceArea, Blocks.CONCRETE.pick(DyeColor.BLACK).defaultBlockState(), false);
 		scene.world().showSection(hiddenReplaceArea, Direction.DOWN);
 		scene.idle(20);
 		scene.overlay().showOutlineWithText(hiddenReplaceArea, 30)

--- a/common/src/client/java/net/createmod/ponder/impl/client/registration/PonderTagBuilder.java
+++ b/common/src/client/java/net/createmod/ponder/impl/client/registration/PonderTagBuilder.java
@@ -6,7 +6,6 @@ import org.jspecify.annotations.Nullable;
 
 import net.createmod.ponder.api.client.registration.TagBuilder;
 import net.minecraft.resources.Identifier;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 
 public class PonderTagBuilder implements TagBuilder {
@@ -18,8 +17,10 @@ public class PonderTagBuilder implements TagBuilder {
 	boolean addToIndex = false;
 	@Nullable
 	Identifier textureIconIdentifier;
-	ItemStack itemIcon = ItemStack.EMPTY;
-	ItemStack mainItem = ItemStack.EMPTY;
+	@Nullable
+	ItemLike itemIcon;
+	@Nullable
+	ItemLike mainItem;
 
 	public PonderTagBuilder(Identifier id, Consumer<PonderTagBuilder> onFinish) {
 		this.id = id;
@@ -64,9 +65,9 @@ public class PonderTagBuilder implements TagBuilder {
 	@Override
 	public TagBuilder item(ItemLike item, boolean useAsIcon, boolean useAsMainItem) {
 		if (useAsIcon)
-			this.itemIcon = new ItemStack(item);
+			this.itemIcon = item;
 		if (useAsMainItem)
-			this.mainItem = new ItemStack(item);
+			this.mainItem = item;
 		return this;
 	}
 

--- a/common/src/client/java/net/createmod/ponder/impl/client/scene/PonderWorldParticles.java
+++ b/common/src/client/java/net/createmod/ponder/impl/client/scene/PonderWorldParticles.java
@@ -1,10 +1,7 @@
 package net.createmod.ponder.impl.client.scene;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.OptionalInt;
 import java.util.Queue;
 
 import org.joml.Matrix4f;
@@ -12,12 +9,7 @@ import org.joml.Matrix4fStack;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
-import com.mojang.blaze3d.pipeline.RenderTarget;
-import com.mojang.blaze3d.systems.GpuDevice;
-import com.mojang.blaze3d.systems.RenderPass;
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.textures.FilterMode;
-import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.PoseStack;
 
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
@@ -29,16 +21,10 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.ParticleEngine;
 import net.minecraft.client.particle.ParticleGroup;
 import net.minecraft.client.particle.ParticleRenderType;
-import net.minecraft.client.renderer.SubmitNodeCollection;
-import net.minecraft.client.renderer.SubmitNodeCollector.ParticleGroupRenderer;
-import net.minecraft.client.renderer.SubmitNodeStorage;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.culling.Frustum;
-import net.minecraft.client.renderer.feature.ParticleFeatureRenderer;
-import net.minecraft.client.renderer.feature.ParticleFeatureRenderer.ParticleBufferCache;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.state.level.ParticlesRenderState;
-import net.minecraft.client.renderer.state.level.QuadParticleRenderState;
-import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.core.particles.ParticleLimit;
 
 public class PonderWorldParticles {
@@ -47,7 +33,6 @@ public class PonderWorldParticles {
 	private final Queue<Particle> particlesToAdd = Queues.newArrayDeque();
 	private final Object2IntOpenHashMap<ParticleLimit> trackedParticleCounts = new Object2IntOpenHashMap<>();
 	private final ParticleEngine particleEngine = Minecraft.getInstance().particleEngine;
-	private final ParticleFeatureRenderer.ParticleBufferCache particleBufferCache = new ParticleFeatureRenderer.ParticleBufferCache();
 
 	PonderLevel world;
 
@@ -79,7 +64,7 @@ public class PonderWorldParticles {
 		}
 	}
 
-	public void renderParticles(PoseStack poseStack, SubmitNodeStorage queue, Camera camera, CameraRenderState cameraRenderState, float partialTick) {
+	public void renderParticles(PoseStack poseStack, SubmitNodeCollector queue, Camera camera, CameraRenderState cameraRenderState, float partialTick) {
 		Matrix4fStack stack = RenderSystem.getModelViewStack();
 		stack.pushMatrix();
 		stack.mul(poseStack.last().pose());
@@ -92,56 +77,9 @@ public class PonderWorldParticles {
 		}
 
 		particleState.submit(queue, cameraRenderState);
-
-		for (SubmitNodeCollection collection : queue.getSubmitsPerOrder().values()) {
-			this.render(collection, false);
-			this.render(collection, true);
-		}
-
 		particleState.reset();
 
 		stack.popMatrix();
-	}
-
-	private void render(SubmitNodeCollection nodeCollection, boolean translucent) {
-		List<ParticleGroupRenderer> renderers = nodeCollection.getParticleGroupRenderers();
-		if (renderers.isEmpty())
-			return;
-
-		GpuDevice device = RenderSystem.getDevice();
-		Minecraft minecraft = Minecraft.getInstance();
-		TextureManager textureManager = minecraft.getTextureManager();
-		RenderTarget mainTarget = minecraft.getMainRenderTarget();
-		RenderTarget particleTarget = minecraft.levelRenderer.getParticlesTarget();
-		GpuTextureView overrideColorView = RenderSystem.outputColorTextureOverride;
-		GpuTextureView overrideDepthView = RenderSystem.outputDepthTextureOverride;
-
-		for (ParticleGroupRenderer renderer : renderers) {
-			if (renderer.isEmpty())
-				continue;
-
-			ParticleBufferCache buffer = new ParticleBufferCache();
-			QuadParticleRenderState.PreparedBuffers prepared = renderer.prepare(buffer, translucent);
-			if (prepared == null)
-				continue;
-
-			boolean useParticleTarget = particleTarget != null && translucent;
-			GpuTextureView colorTextureView = overrideColorView != null ? overrideColorView : useParticleTarget ? particleTarget.getColorTextureView() : mainTarget.getColorTextureView();
-			GpuTextureView depthTextureView = overrideDepthView != null ? overrideDepthView : useParticleTarget ? particleTarget.getDepthTextureView() : mainTarget.getDepthTextureView();
-
-			try (RenderPass renderPass = createRenderPass(device, colorTextureView, depthTextureView, translucent)) {
-				this.prepareRenderPass(renderPass);
-				renderer.render(prepared, buffer, renderPass, textureManager);
-			}
-		}
-	}
-
-	private void prepareRenderPass(RenderPass renderPass) {
-		renderPass.setUniform("Projection", RenderSystem.getProjectionMatrixBuffer());
-		renderPass.setUniform("Fog", RenderSystem.getShaderFog());
-		renderPass.bindTexture(
-			"Sampler2", Minecraft.getInstance().gameRenderer.lightmap(), RenderSystem.getSamplerCache().getClampToEdge(FilterMode.LINEAR)
-		);
 	}
 
 	protected void updateCount(ParticleLimit limit, int count) {
@@ -156,12 +94,6 @@ public class PonderWorldParticles {
 		this.particles.clear();
 		this.particlesToAdd.clear();
 		this.trackedParticleCounts.clear();
-	}
-
-	private static RenderPass createRenderPass(GpuDevice device, GpuTextureView color, GpuTextureView depth, boolean translucent) {
-		return device.createCommandEncoder().createRenderPass(
-			() -> "Ponder Particles - " + (translucent ? "Translucent" : "Solid"), color, OptionalInt.empty(), depth, OptionalDouble.empty()
-		);
 	}
 
 	public static class ParticlesFrustum extends Frustum {

--- a/common/src/client/java/net/createmod/ponder/impl/client/tooltip/ContainerScreenHoveredItemProvider.java
+++ b/common/src/client/java/net/createmod/ponder/impl/client/tooltip/ContainerScreenHoveredItemProvider.java
@@ -12,10 +12,10 @@ enum ContainerScreenHoveredItemProvider implements HoveredItemProvider {
 
 	@Override
 	public Item determineHoveredItem() {
-		if (!(Minecraft.getInstance().screen instanceof AbstractContainerScreenAccessor screen))
+		if (!(Minecraft.getInstance().gui.screen() instanceof AbstractContainerScreenAccessor screen))
 			return Items.AIR;
 
-		Slot slot = screen.getHoveredSlot();
+		Slot slot = screen.ponder$getHoveredSlot();
 		return slot == null ? Items.AIR : slot.getItem().getItem();
 	}
 

--- a/common/src/client/java/net/createmod/ponder/impl/client/tooltip/PonderTooltipHandler.java
+++ b/common/src/client/java/net/createmod/ponder/impl/client/tooltip/PonderTooltipHandler.java
@@ -73,7 +73,7 @@ public final class PonderTooltipHandler {
 	}
 
 	private static void openPonder(Item item) {
-		Screen currentScreen = Minecraft.getInstance().screen;
+		Screen currentScreen = Minecraft.getInstance().gui.screen();
 		if (currentScreen instanceof NavigatableSimiScreen simiScreen) {
 			simiScreen.centerScalingOnMouse();
 		}
@@ -139,7 +139,7 @@ public final class PonderTooltipHandler {
 	}
 
 	private static Item determineHoveredItem() {
-		if (Minecraft.getInstance().screen == null)
+		if (Minecraft.getInstance().gui.screen() == null)
 			return Items.AIR;
 
 		for (HoveredItemProvider provider : hoveredItemProviders) {
@@ -170,7 +170,7 @@ public final class PonderTooltipHandler {
 	// when the hovered block is the current subject, we don't want to do this, since that would just
 	// open the same scene again. instead, replace it with a 'Subject of this scene' message.
 	private static boolean isCurrentPonderSubject(Item item) {
-		if (Minecraft.getInstance().screen instanceof PonderUI ponder) {
+		if (Minecraft.getInstance().gui.screen() instanceof PonderUI ponder) {
 			return ponder.getSubject().getItem() == item;
 		}
 

--- a/common/src/client/resources/ponder-common-client.mixins.json
+++ b/common/src/client/resources/ponder-common-client.mixins.json
@@ -3,7 +3,7 @@
   "minVersion": "0.8",
   "package": "net.createmod.ponder.impl.client.mixin",
   "compatibilityLevel": "JAVA_25",
-  "mixins": [
+  "client": [
     "AbstractContainerScreenAccessor",
     "GuiGraphicsExtractorAccessor",
     "TooltipRenderUtilMixin"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,17 @@
 [versions]
-minecraft = "26.1.2"
-flywheel = "1.0.6-beta"
+minecraft = "26.2"
+flywheel = "1.0.7"
 
 # https://neoforged.net/
-neoforge = "26.1.2.75"
+neoforge = "26.2.0.8-beta"
+fml-loader = "11.0.13"
+night-config = "3.8.3"
 mdg = "2.0.+"
 
 # https://fabricmc.net/develop/
 loom = "1.16.+"
 fabric-loader = "0.19.3"
-fabric-api = "0.150.0+26.1.2"
+fabric-api = "0.154.2+26.2"
 
 # we need to manually depend on mixin (+extras) in common
 mixin = "0.17.3+mixin.0.8.7"
@@ -19,17 +21,22 @@ mixin-extras = "0.5.4"
 minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
 fabric-loader = { module = "net.fabricmc:fabric-loader", version.ref = "fabric-loader" }
 fabric-api = { module = "net.fabricmc.fabric-api:fabric-api", version.ref = "fabric-api" }
+neoforge = { module = "net.neoforged:neoforge", version.ref = "neoforge" }
+fml-loader = { module = "net.neoforged.fancymodloader:loader", version.ref = "fml-loader" }
+night-config-core = { module = "com.electronwill.night-config:core", version.ref = "night-config" }
+night-config-toml = { module = "com.electronwill.night-config:toml", version.ref = "night-config" }
 mixin = { module = "net.fabricmc:sponge-mixin", version.ref = "mixin" }
 mixin-extras = { module = "io.github.llamalad7:mixinextras-common", version.ref = "mixin-extras" }
 
-flywheel-neoforge-api = { module = "dev.engine-room.flywheel:flywheel-neoforge-api-26.1", version.ref = "flywheel" }
-flywheel-neoforge = { module = "dev.engine-room.flywheel:flywheel-neoforge-26.1", version.ref = "flywheel" }
-flywheel-fabric-api = { module = "dev.engine-room.flywheel:flywheel-fabric-api-26.1", version.ref = "flywheel" }
-flywheel-fabric = { module = "dev.engine-room.flywheel:flywheel-fabric-26.1", version.ref = "flywheel" }
+flywheel-neoforge-api = { module = "dev.engine-room.flywheel:flywheel-neoforge-api-26.2", version.ref = "flywheel" }
+flywheel-neoforge = { module = "dev.engine-room.flywheel:flywheel-neoforge-26.2", version.ref = "flywheel" }
+flywheel-fabric-api = { module = "dev.engine-room.flywheel:flywheel-fabric-api-26.2", version.ref = "flywheel" }
+flywheel-fabric = { module = "dev.engine-room.flywheel:flywheel-fabric-26.2", version.ref = "flywheel" }
 
 [bundles]
 fabric = [ "fabric-loader", "fabric-api" ]
 mixin = [ "mixin", "mixin-extras" ]
+neoforge-config = [ "neoforge", "fml-loader", "night-config-core", "night-config-toml" ]
 
 [plugins]
 mdg = { id = "net.neoforged.moddev", version.ref = "mdg" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/neoforge/src/main/java/net/createmod/ponder/neoforge/NeoForgePonder.java
+++ b/neoforge/src/main/java/net/createmod/ponder/neoforge/NeoForgePonder.java
@@ -1,26 +1,34 @@
 package net.createmod.ponder.neoforge;
 
+import java.util.Map;
+import java.util.Set;
+
+import net.createmod.catnip.api.config.ConfigBase;
 import net.createmod.ponder.api.Ponder;
 import net.createmod.ponder.impl.command.PonderCommands;
+import net.createmod.ponder.impl.config.PonderConfig;
 
+import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 
 @Mod(Ponder.MOD_ID)
 public class NeoForgePonder {
-	public NeoForgePonder(ModContainer container) {
+	public NeoForgePonder(ModContainer container, IEventBus modEventBus) {
 		registerConfigs(container);
+		modEventBus.addListener(NeoForgePonder::onLoad);
+		modEventBus.addListener(NeoForgePonder::onReload);
 	}
 
 	private static void registerConfigs(ModContainer container) {
-		// FIXME: config
-		// Set<Map.Entry<ModConfig.Type, ConfigBase>> entries = PonderConfig.registerConfigs();
-		// for (Map.Entry<ModConfig.Type, ConfigBase> entry : entries) {
-		// 	continue;.registerConfig(entry.getKey(), entry.getValue().specification);
-		// }
+		Set<Map.Entry<ModConfig.Type, ConfigBase>> entries = PonderConfig.registerConfigs();
+		for (Map.Entry<ModConfig.Type, ConfigBase> entry : entries)
+			container.registerConfig(entry.getKey(), entry.getValue().specification);
 	}
 
 	@EventBusSubscriber
@@ -31,17 +39,11 @@ public class NeoForgePonder {
 		}
 	}
 
-	// FIXME: config
-	// @EventBusSubscriber(bus = Bus.MOD)
-	// public static class ModBusEvents {
-	// 	@SubscribeEvent
-	// 	public static void onLoad(ModConfigEvent.Loading event) {
-	// 		PonderConfig.onLoad(event.getConfig());
-	// 	}
-	//
-	// 	@SubscribeEvent
-	// 	public static void onReload(ModConfigEvent.Reloading event) {
-	// 		PonderConfig.onReload(event.getConfig());
-	// 	}
-	// }
+	public static void onLoad(ModConfigEvent.Loading event) {
+		PonderConfig.onLoad(event.getConfig());
+	}
+
+	public static void onReload(ModConfigEvent.Reloading event) {
+		PonderConfig.onReload(event.getConfig());
+	}
 }

--- a/neoforge/src/main/java/net/createmod/ponder/render/VirtualRenderHelper.java
+++ b/neoforge/src/main/java/net/createmod/ponder/render/VirtualRenderHelper.java
@@ -1,0 +1,15 @@
+package net.createmod.ponder.render;
+
+import net.neoforged.neoforge.model.data.ModelData;
+import net.neoforged.neoforge.model.data.ModelProperty;
+
+public class VirtualRenderHelper {
+	public static final ModelProperty<Boolean> VIRTUAL_PROPERTY = new ModelProperty<>();
+	public static final ModelData VIRTUAL_DATA = ModelData.builder()
+		.with(VIRTUAL_PROPERTY, true)
+		.build();
+
+	public static boolean isVirtual(ModelData data) {
+		return data != null && data.has(VIRTUAL_PROPERTY) && Boolean.TRUE.equals(data.get(VIRTUAL_PROPERTY));
+	}
+}

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -18,6 +18,9 @@ config="ponder.mixins.json"
 [[mixins]]
 config="ponder-common.mixins.json"
 
+[[mixins]]
+config="ponder-common-client.mixins.json"
+
 [[dependencies.ponder]]
 modId = "neoforge"
 type="required"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,14 @@ plugins {
 
 rootProject.name = "ponder"
 
-for (platform in listOf("common", "fabric", "neoforge")) {
+val platforms = providers.gradleProperty("ponder.platforms")
+    .orNull
+    ?.split(",")
+    ?.map(String::trim)
+    ?.filter(String::isNotEmpty)
+    ?: listOf("common", "fabric", "neoforge")
+
+for (platform in platforms) {
     include(platform)
 
     include(":catnip:$platform")


### PR DESCRIPTION
## Summary
- Port Ponder and Catnip to Minecraft 26.2 / NeoForge 26.2.0.8-beta.
- Move Java/CI/Gradle metadata to Java 25 and Gradle 9.6.1.
- Update Flywheel dependency coordinates for the official 26.2 artifacts.
- Port client config UI, picture-in-picture renderers, tooltip/mixin accessors, virtual render helpers, client packet payloads, and client mixin registration to 26.2 APIs.
- Guard Catnip clientbound packet handler bridge registration to client physical side while still registering clientbound codecs on both sides.
- Use common `Player` in the client payload handler API so dedicated-server packet registration no longer probes `LocalPlayer`.
- Keep Ponder GUI client mixin entries server-safe. NeoForge still selects the declared client mixin config on the server, but the dedicated server no longer reports client-class load errors.

## Maintainer Note
- The release plan calls for upstream `mc26.2/dev` to be created from `mc26.1/dev` before merge.
- This account cannot create upstream branches (`403`), so this PR is opened against `mc26.1/dev` and should be retargeted to `mc26.2/dev` after maintainers create it.

## Validation
- `./gradlew -Pponder.platforms=common,neoforge -Pponder.useMavenLocal --offline :catnip:common:publishToMavenLocal :catnip:neoforge:publishToMavenLocal :common:publishToMavenLocal :neoforge:publishToMavenLocal --console=plain` -> `BUILD SUCCESSFUL in 5s`
- Downstream Create dedicated-server smoke reaches `Done` with no `LocalPlayer`, `DISTXFORM`, or unresolved Ponder/Catnip version-difference warnings.

## Release Train
- Publish official `ponder-neoforge:1.0.90+mc26.2` artifacts after Flywheel 26.2 artifacts are available.
