### PR TITLE
Fix solid outlines rendered after deferred pass

### DIFF
--- a/Common/src/main/java/net/createmod/catnip/render/PonderRenderTypes.java
+++ b/Common/src/main/java/net/createmod/catnip/render/PonderRenderTypes.java
@@ -17,7 +17,7 @@ public abstract class PonderRenderTypes extends RenderType {
 
 	private static final RenderType OUTLINE_SOLID =
 		RenderTypeAccessor.catnip$create(createLayerName("outline_solid"), DefaultVertexFormat.NEW_ENTITY, VertexFormat.Mode.QUADS, 256, false, false, RenderType.CompositeState.builder()
-			.setShaderState(RENDERTYPE_ENTITY_SOLID_SHADER)
+			.setShaderState(RENDERTYPE_ENTITY_TRANSLUCENT_CULL_SHADER)
 			.setTextureState(new RenderStateShard.TextureStateShard(PonderSpecialTextures.BLANK.getLocation(), false, false))
 			.setCullState(CULL)
 			.setLightmapState(LIGHTMAP)


### PR DESCRIPTION
## Summary

- Route solid Ponder outlines through the forward entity shader.
- Keep the existing opaque blend, depth-write, cull, and vertex states.

## Root cause

Ponder flushes outlines during `AFTER_PARTICLES`. With deferred shader packs,
the opaque entity G-buffer has already been consumed at that point, so the
solid outline program writes no visible scene color. Translucent outline faces
still render, which leaves Create's glue texture visible without its green
selection border.

## Compatibility

The change only replaces the shader used by Ponder's `outline_solid` render
type. It does not enable blending or alter depth, culling, sorting, texture, or
vertex-format state, so standalone opaque outline behavior remains unchanged.

## Validation

- `BUILD_NUMBER=92-decoderfix.1 .\gradlew.bat Forge:build`
- `BUILD_NUMBER=92-decoderfix.1 .\gradlew.bat Fabric:build`
- Forge runtime with Create 6.0.8, Oculus, and Photon
- Visual confirmation of Create's green glue-selection border
